### PR TITLE
chore(apigateway): remove hardcoded sport enum from openapi spec

### DIFF
--- a/packages/apigateway/openapi.yaml
+++ b/packages/apigateway/openapi.yaml
@@ -160,10 +160,15 @@ paths:
             example: '2025-12-31'
         - name: sport
           in: query
-          description: Filter by sport category
+          description: >-
+            Filter by sport category. The canonical list of valid values
+            is returned by `GET /v1/sports/config` (sourced from
+            `schemas/sports/sport_types.json`). Common examples: cycling,
+            running, hiking, swimming, yoga, walking. Enum intentionally
+            omitted so the spec doesn't go stale when categories are
+            added — fetch the live list from the endpoint instead.
           schema:
             type: string
-            enum: [cycling, running, yoga]
         - name: limit
           in: query
           description: Maximum results per page
@@ -354,10 +359,15 @@ components:
       name: sport
       in: query
       required: true
-      description: Sport category
+      description: >-
+        Sport category. The canonical list of valid values is returned by
+        `GET /v1/sports/config` (sourced from
+        `schemas/sports/sport_types.json`). Common examples: cycling,
+        running, hiking, swimming, yoga, walking. Enum intentionally
+        omitted so the spec doesn't go stale when categories are
+        added — fetch the live list from the endpoint instead.
       schema:
         type: string
-        enum: [cycling, running, yoga]
 
   responses:
     BadRequest:
@@ -470,7 +480,10 @@ components:
           description: Strava activity type (Ride, Run, Yoga, etc.)
         sport:
           type: string
-          description: Categorized sport (cycling, running, yoga)
+          description: >-
+            Categorized sport. See `GET /v1/sports/config` for the full
+            list of categories (sourced from
+            `schemas/sports/sport_types.json`).
         start_date_local:
           type: string
           format: date-time
@@ -629,7 +642,9 @@ components:
           description: Activity name
         sport:
           type: string
-          description: Categorized sport (cycling, running, etc.)
+          description: >-
+            Categorized sport. See `GET /v1/sports/config` for the full
+            list of categories.
         distance:
           type: number
           format: double


### PR DESCRIPTION
The /v1/activities `sport` query param and the reusable `sport` component had a hardcoded `enum: [cycling, running, yoga]` that drifted from schemas/sports/sport_types.json (which is now the canonical sport registry). Removes the enum and points the description at GET /v1/sports/config so clients fetch the live list rather than relying on a stale spec.

Also reworded two response-field descriptions that listed ("cycling, running, yoga") / ("cycling, running, etc.") inline to point at the endpoint instead.