### PR TITLE
feat(observability): X-Trace-Id response header for browser↔backend r…

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -114,6 +114,8 @@ The React frontend propagates W3C trace context so a UI action can be tied to th
 
 Because the apigateway is public-endpoint-mode (the row above), it **links, never parents** on this header: the browser trace-id is a correlation *hint*, not a trusted parent, and a fresh per-request span-id is just a correlation handle. In Cloud Trace this appears as the apigateway's fresh root span carrying the browser navigation's span context as a `Link` — not as a browser-rooted trace tree. For finding and reading these (including the per-plane attribute/log/metric naming that differs by signal), see [docs/runbooks/reading-traces.md](../runbooks/reading-traces.md).
 
+**Current state (2026-05-19):** the apigateway-side mechanism above is verified working — a direct `curl` to the Cloud Run origin with `traceparent: 00-aaaa…-bbbb…-01` produces a fresh-root trace whose root-span `Link == aaaa…/bbbb…`. **However, in the deployed browser path the `Link` target is the Google-edge `X-Cloud-Trace-Context` (a GFE-owned trace with a missing parent), not the browser's `traceparent`.** An intermediate hop between the browser and Cloud Run drops or replaces the W3C `traceparent` header before it reaches Go, so the end-to-end "click → backend traces" correlation through this mechanism is **not** currently achieved. Reverse-correlation via the `trace_id` field on error responses (apierrors) still works. Locating the hop and choosing a remediation (proxy/ingress config fix vs. browser OTel SDK vs. extending reverse-correlation to success responses) is queued as follow-up work.
+
 ## Trace IDs in error responses
 
 API error responses include the active span's `trace_id` so support can jump straight to Cloud Trace from a bug report:
@@ -128,6 +130,8 @@ API error responses include the active span's `trace_id` so support can jump str
 ```
 
 The field is the **raw 32-char hex** (no `projects/<p>/traces/` prefix) — paste-friendly for users. Implemented in [`packages/shared/apierrors/response.go`](../../packages/shared/apierrors/response.go); both the dispatcher and apigateway pick it up automatically because they share the apierrors package. The field is `omitempty`, so requests without an active span don't emit a misleading empty value.
+
+Apigateway also stamps the same value on **every response** (success and error) as the `X-Trace-Id` header via [`TraceIDResponseHeader`](../../packages/shared/otel/chi.go) middleware, and exposes it cross-origin via CORS `Access-Control-Expose-Headers`. The browser axios client ([`packages/web/src/api/client.ts`](../../packages/web/src/api/client.ts)) reads it and logs to console in dev. This is the success-path / opaque-failure backstop for the apierrors body field, which only covers apierrors-shaped errors — network failures, gateway 5xxs, and other non-apierrors paths still get a trace handle via the header.
 
 ## Sampling
 
@@ -253,7 +257,7 @@ resolution for custom metrics).
 ### Span ↔ metric alignment
 
 For most histograms, the `operation` label value matches the span name
-1:1 (after the [alignment cleanup](../../../desirelines-planning/tasks/completed/align-apigateway-histogram-labels-and-cleanup-not-found-paths.md)).
+1:1 (convention adopted after a histogram-label alignment cleanup).
 That makes "find the metric for span X" mechanical:
 
 - Span `repository.activities.list_routes` → histogram `postgres/query.duration{operation="list_routes"}`
@@ -293,7 +297,7 @@ Useful context for reading the OTel code:
 - **Trace context propagation across Pub/Sub** was added once and has stayed stable. The Go side injects via `propagation.MapCarrier(attrs)` on the message attributes; the Python side extracts via `opentelemetry.propagate.extract()`. If a future change rebuilds the publish path or a new subscriber gets added, that propagation chain is the easy thing to forget.
 - **`PubSubMessage.attributes`** was originally dropped silently on the Python side. It's now a `dict[str, str]` field on the model and the `correlation_id` from the dispatcher flows through. Test fixtures that build PubSub bodies must include attributes.
 
-For the regression-test angle (a synthetic webhook driven through all 5 hops asserting a single trace_id), see the planning task [`tasks/next-up/e2e-trace-propagation-test.md`](../../../desirelines-planning/tasks/next-up/e2e-trace-propagation-test.md) — not yet implemented.
+For the regression-test angle (a synthetic webhook driven through all 5 hops asserting a single `trace_id` end-to-end), an end-to-end propagation test is on the backlog but not yet implemented.
 
 ## See also
 

--- a/docs/runbooks/reading-traces.md
+++ b/docs/runbooks/reading-traces.md
@@ -14,6 +14,18 @@ If the user has an error response, it includes `trace_id` (raw 32-char hex):
 
 GCP Console → **Trace explorer** → paste the ID into the search bar. Done.
 
+### From the browser console (any internal API request, dev mode)
+
+Apigateway stamps `X-Trace-Id` on every response (set by `TraceIDResponseHeader` middleware, exposed cross-origin via CORS). In a dev build the axios client logs it on success and error:
+
+```
+[API] GET activities/2026/metadata → trace_id=32beef1f57fe81b77a21a940a9e90080
+```
+
+Copy the hex into Trace explorer's search bar — same path as the user-reported-error flow. This works for the success path too (apierrors only inlines `trace_id` in error response bodies), and survives cases where the response isn't apierrors-shaped (network glitches, opaque 5xxs from an intermediary, etc.).
+
+If you only have the response in DevTools' Network tab and not the console line, the value is on the response headers as `x-trace-id` — same trace_id, paste-friendly.
+
 ### From a known activity ID
 
 Cloud Trace doesn't index by activity_id directly, but spans carry it as an attribute. Two ways to find the trace:

--- a/packages/apigateway/internal/server/router.go
+++ b/packages/apigateway/internal/server/router.go
@@ -91,6 +91,11 @@ func NewRouter(cfg RouterConfig, public PublicRoutes, auth AuthenticatedRoutes, 
 	r.Use(gcplog.WithCloudTraceContext)
 	r.Use(otel.SpanNameFromChiRoute)
 	r.Use(otel.StampRequestID)
+	// Stamp X-Trace-Id on every response so the frontend can correlate a
+	// browser-side log/error to a Cloud Trace, even on the success path
+	// (apierrors only emits trace_id in error response bodies). Exposed
+	// cross-origin via CORS Access-Control-Expose-Headers in CORSMiddleware.
+	r.Use(otel.TraceIDResponseHeader)
 	r.Use(gcplog.HTTPRequestLoggerWithMetrics(logger, cfg.HTTPHistogram))
 	r.Use(chiMiddleware.Recoverer)
 

--- a/packages/apigateway/pkg/cors/cors.go
+++ b/packages/apigateway/pkg/cors/cors.go
@@ -55,6 +55,10 @@ func (h *Handler) SetHeaders(w http.ResponseWriter, r *http.Request) bool {
 	if h.allowedOrigins[origin] {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		// Expose backend trace id (set by otel.TraceIDResponseHeader) so the
+		// browser can read it cross-origin via response.headers.get(). Without
+		// this, the header reaches the browser but is hidden from JS.
+		w.Header().Set("Access-Control-Expose-Headers", "X-Trace-Id")
 		w.Header().Add("Vary", "Origin")
 		return true
 	}

--- a/packages/apigateway/pkg/cors/cors_test.go
+++ b/packages/apigateway/pkg/cors/cors_test.go
@@ -177,6 +177,12 @@ func TestHandler_SetHeaders(t *testing.T) {
 				if credHeader != "true" {
 					t.Errorf("Access-Control-Allow-Credentials = %q, want 'true'", credHeader)
 				}
+				// X-Trace-Id must be exposed so cross-origin JS can read the
+				// backend trace handle stamped by otel.TraceIDResponseHeader.
+				exposeHeader := w.Header().Get("Access-Control-Expose-Headers")
+				if !strings.Contains(exposeHeader, "X-Trace-Id") {
+					t.Errorf("Access-Control-Expose-Headers = %q, want it to contain 'X-Trace-Id'", exposeHeader)
+				}
 			}
 		})
 	}

--- a/packages/shared/otel/chi.go
+++ b/packages/shared/otel/chi.go
@@ -110,6 +110,27 @@ func AddChiURLParamsAs(r *http.Request, aliases map[string]string) {
 	}
 }
 
+// TraceIDResponseHeader is middleware that stamps `X-Trace-Id` on the response
+// from the active OpenTelemetry span's trace_id (raw 32-char hex), so success
+// and error responses both carry a backend trace handle the browser can
+// correlate from. Mirrors the `traceId` field surfaced in error response bodies
+// by apierrors.WriteError, but covers the success path too.
+//
+// Place inside the otelhttp wrapper so a server span exists, and run it before
+// any handler writes a response body — once headers are flushed they are
+// immutable. The header is read by cross-origin browsers only if it is also
+// listed in CORS `Access-Control-Expose-Headers` (configured at the apigateway
+// CORS handler). No-op if no valid span is active in the request context.
+func TraceIDResponseHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sc := trace.SpanContextFromContext(r.Context())
+		if sc.IsValid() {
+			w.Header().Set("X-Trace-Id", sc.TraceID().String())
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // StampRequestID is middleware that copies the chi-generated request ID (already
 // bridged into the request context by gcplog.BridgeRequestID) onto the active
 // OpenTelemetry server span as `request_id`.

--- a/packages/shared/otel/chi_test.go
+++ b/packages/shared/otel/chi_test.go
@@ -336,3 +336,78 @@ func TestAddChiURLParamsAs_NoActiveSpanIsNoOp(t *testing.T) {
 		t.Errorf("status = %d, want 200", w.Code)
 	}
 }
+
+func TestTraceIDResponseHeader_SetsHeaderFromActiveSpan(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	tr := tp.Tracer("test")
+
+	r := chi.NewRouter()
+	r.Use(TraceIDResponseHeader)
+	r.Get("/x", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	ctx, span := tr.Start(req.Context(), "server")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	span.End()
+
+	want := span.SpanContext().TraceID().String()
+	if got := w.Header().Get("X-Trace-Id"); got != want {
+		t.Errorf("X-Trace-Id = %q, want %q", got, want)
+	}
+}
+
+func TestTraceIDResponseHeader_NoActiveSpanIsNoOp(t *testing.T) {
+	// No tracer / no span in context — middleware must not panic and must
+	// not set a placeholder/empty header value.
+	r := chi.NewRouter()
+	r.Use(TraceIDResponseHeader)
+	r.Get("/x", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get("X-Trace-Id"); got != "" {
+		t.Errorf("X-Trace-Id should be unset when no active span, got %q", got)
+	}
+}
+
+func TestTraceIDResponseHeader_HeaderPresentEvenOnHandlerError(t *testing.T) {
+	// The header is stamped before the handler runs, so an error response
+	// (4xx/5xx) still carries it. This is the whole point: reverse
+	// correlation works on failures too, not just success.
+	tp := sdktrace.NewTracerProvider()
+	tr := tp.Tracer("test")
+
+	r := chi.NewRouter()
+	r.Use(TraceIDResponseHeader)
+	r.Get("/x", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	ctx, span := tr.Start(req.Context(), "server")
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	span.End()
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	want := span.SpanContext().TraceID().String()
+	if got := w.Header().Get("X-Trace-Id"); got != want {
+		t.Errorf("X-Trace-Id on 500 = %q, want %q", got, want)
+	}
+}

--- a/packages/web/eslint.config.js
+++ b/packages/web/eslint.config.js
@@ -101,8 +101,7 @@ export default tseslint.config(
   //   - `unbound-method`: vitest/jest `expect(mock.method).toHaveBeen...` is safe
   //   - `require-await`: RTL `act(async () => { ... })` without explicit await is idiomatic
   // Real-bug rules (no-floating-promises, no-misused-promises, etc.) remain enforced.
-  // Tracked for future full-fix: see
-  // desirelines-planning/tasks/ready-to-start/extend-type-aware-lint-strictness-to-tests.md
+  // Tracked for future full-fix in the project backlog.
   {
     files: [
       "**/*.test.ts",

--- a/packages/web/src/api/client.test.ts
+++ b/packages/web/src/api/client.test.ts
@@ -7,6 +7,18 @@ vi.mock("../lib/config", () => ({
   getConfig: () => ({ apiGatewayUrl: "https://api.example.com" }),
 }));
 
+// Spy on logger so the X-Trace-Id interceptor tests can assert debug output.
+// Other test blocks ignore it; the mocked logger silently absorbs unrelated
+// calls instead of writing to the real console during tests.
+vi.mock("../lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 // Shared mock auth service — configureClientAuth only registers interceptors
 // once (singleton guard), so the same mock instance is captured in the closure
 // for the entire test suite.
@@ -27,6 +39,9 @@ const mockAuthService: AuthService = {
 
 // Import after mocks are set up
 import getClient, { configureClientAuth, resetClient } from "./client";
+import { logger } from "../lib/logger";
+
+const mockLogger = vi.mocked(logger);
 
 let client: ReturnType<typeof getClient>;
 
@@ -170,6 +185,67 @@ describe("traceparent request interceptor", () => {
     const b = traceparentOf(seen[1])?.split("-");
     expect(a?.[1]).toBe(b?.[1]); // same trace-id (no navigation between)
     expect(a?.[2]).not.toBe(b?.[2]); // distinct span-id per request
+  });
+});
+
+describe("X-Trace-Id response logging (dev-only)", () => {
+  beforeEach(() => {
+    resetClient();
+    client = getClient();
+    configureClientAuth(mockAuthService);
+    mockLogger.debug.mockClear();
+  });
+
+  const TRACE_ID = "1234abcd5678ef901234abcd5678ef90";
+
+  it("logs the backend trace_id from X-Trace-Id on success responses", async () => {
+    client.defaults.adapter = vi.fn().mockImplementation((config: InternalAxiosRequestConfig) =>
+      Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        headers: { "x-trace-id": TRACE_ID },
+        config,
+        data: { ok: true },
+      })
+    );
+
+    await client.get("activities");
+
+    const matched = mockLogger.debug.mock.calls.some(
+      ([msg]) => typeof msg === "string" && msg.includes(`trace_id=${TRACE_ID}`)
+    );
+    expect(matched).toBe(true);
+  });
+
+  it("logs the backend trace_id from X-Trace-Id on error responses", async () => {
+    client.defaults.adapter = vi.fn().mockImplementation((config: InternalAxiosRequestConfig) => {
+      const err = createAxiosError(500, config);
+      // createAxiosError defaults to empty headers; attach our trace id.
+      if (err.response) err.response.headers = { "x-trace-id": TRACE_ID };
+      return Promise.reject(err);
+    });
+
+    await expect(client.get("activities")).rejects.toThrow();
+
+    const matched = mockLogger.debug.mock.calls.some(
+      ([msg]) => typeof msg === "string" && msg.includes(`trace_id=${TRACE_ID}`)
+    );
+    expect(matched).toBe(true);
+  });
+
+  it("does not log when the header is absent", async () => {
+    client.defaults.adapter = vi
+      .fn()
+      .mockImplementation((config: InternalAxiosRequestConfig) =>
+        Promise.resolve({ status: 200, statusText: "OK", headers: {}, config, data: {} })
+      );
+
+    await client.get("activities");
+
+    const matched = mockLogger.debug.mock.calls.some(
+      ([msg]) => typeof msg === "string" && msg.includes("trace_id=")
+    );
+    expect(matched).toBe(false);
   });
 });
 

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -18,6 +18,18 @@ import { isInternalRequest } from "./url";
 let client: ReturnType<typeof axios.create> | null = null;
 let configured = false;
 
+/**
+ * Case-insensitive read from either a plain header object (axios's default
+ * normalized-lowercase form) or an `AxiosHeaders` instance (which exposes
+ * `.get()`). Returns `undefined` for missing / non-string values.
+ */
+function headerValue(headers: unknown, name: string): string | undefined {
+  if (!headers || typeof headers !== "object") return undefined;
+  const h = headers as Record<string, unknown> & { get?: (n: string) => unknown };
+  const raw = typeof h.get === "function" ? h.get(name) : (h[name.toLowerCase()] ?? h[name]);
+  return typeof raw === "string" ? raw : undefined;
+}
+
 function getClient() {
   if (!client) {
     const config = getConfig();
@@ -48,6 +60,33 @@ function getClient() {
         }
         return reqConfig;
       });
+    }
+
+    // Surface the backend trace id stamped by otel.TraceIDResponseHeader on
+    // every internal API response. Apigateway exposes the header cross-origin
+    // via CORS `Access-Control-Expose-Headers`. apierrors already inlines the
+    // same value in error response bodies, so this is the success-path / opaque-
+    // failure (non-apierrors) backstop. Dev-only logging keeps prod console
+    // quiet; the header is still attached and readable by error-reporting code.
+    if (!config.isProduction) {
+      client.interceptors.response.use(
+        (response) => {
+          const traceId = headerValue(response.headers, "x-trace-id");
+          if (traceId) {
+            const method = response.config.method?.toUpperCase() ?? "GET";
+            logger.debug(`[API] ${method} ${response.config.url} → trace_id=${traceId}`);
+          }
+          return response;
+        },
+        (error: AxiosError) => {
+          const traceId = headerValue(error.response?.headers, "x-trace-id");
+          if (traceId) {
+            const method = error.config?.method?.toUpperCase() ?? "GET";
+            logger.debug(`[API error] ${method} ${error.config?.url} → trace_id=${traceId}`);
+          }
+          return Promise.reject(error);
+        }
+      );
     }
   }
   return client;

--- a/packages/web/src/api/trace.ts
+++ b/packages/web/src/api/trace.ts
@@ -9,8 +9,15 @@
  * a trusted parent — which is exactly what makes injecting it safe.
  *
  * One trace-id is minted per user navigation (wired to TanStack Router in
- * router.tsx) so every request a single navigation fires shares it. In
- * Cloud Trace that surfaces as "this click → these backend traces".
+ * router.tsx) so every request a single navigation fires shares it. The
+ * intent is that Cloud Trace renders the apigateway's fresh-root span with
+ * a `Link` back to this trace-id, surfacing as "this click → these backend
+ * traces". See `docs/architecture/observability.md` ("Browser → apigateway
+ * propagation") for the current end-to-end state — at time of writing the
+ * deployed proxy hop in front of Cloud Run does not preserve the
+ * `traceparent` header, so the correlation is not yet end-to-end in prod;
+ * the per-request `X-Trace-Id` response header is the working backstop in
+ * the meantime.
  */
 
 /** Hex-encode `byteLength` cryptographically-random bytes. */


### PR DESCRIPTION
…everse-correlation

Stamp the active OTel span's trace_id as `X-Trace-Id` on every apigateway response (success + error) via a new chi middleware, exposed cross-origin via CORS. Dev-only axios response interceptor logs `method url → trace_id=…` so a console scan surfaces a backend trace handle for any internal call; prod is silent but the header is still attached for any error-reporting hook.

Complements the apierrors `traceId` body field (errors only) — and matters now because forward-propagation of the browser's W3C `traceparent` is currently defeated by the Firebase Hosting proxy hop in front of Cloud Run, so reverse-correlation via this header is the working backstop until that's resolved separately.

Header name `X-Trace-Id` chosen over the W3C draft `traceresponse` (still in flux); switching later is a 3-line change.

Docs: new paragraph in observability.md and a "From the browser console" entry in reading-traces.md so it's discoverable.