### PR TITLE
fix(stravapipe): install production deps from uv.lock in Dockerfile

### DIFF
--- a/packages/stravapipe/BUILD
+++ b/packages/stravapipe/BUILD
@@ -57,6 +57,10 @@ files(
     name="docker_sources",
     sources=[
         "pyproject.toml",
+        # `uv.lock` is the production resolve — the Dockerfile installs
+        # via `uv sync --frozen` so prod pins to the same versions as
+        # local dev and (transitively) CI.
+        "uv.lock",
         "README.md",
         "src/**/*.py",
         "src/**/*.json",  # Include any JSON config files

--- a/packages/stravapipe/Dockerfile
+++ b/packages/stravapipe/Dockerfile
@@ -3,34 +3,58 @@
 # Cloud Run overrides the CMD at deployment time for each service/job.
 #
 # Multi-stage build for optimal container size.
+#
+# Production deps install from `uv.lock` (`uv sync --frozen`) so every
+# Docker build pins to exactly the same versions Pants and local dev
+# resolve to. Without `--frozen`, the build would re-resolve from
+# `pyproject.toml` against PyPI each time and drift independently.
 
 ARG PYTHON_VERSION=3.14
 
 # Build stage
 FROM python:${PYTHON_VERSION}-slim AS builder
 
-WORKDIR /build
+# Same WORKDIR as runtime so the venv ends up at /app/.venv in both
+# stages — uv-generated entry-point scripts (uvicorn etc.) bake their
+# interpreter path into the shebang at install time, so the builder and
+# runtime venv paths MUST match or `exec uvicorn` fails with
+# "no such file or directory" at runtime.
+WORKDIR /app
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /uvx /bin/
 
-# Copy package files for dependency installation (context is packages/stravapipe)
-COPY pyproject.toml README.md ./
-COPY src/ ./src/
+# UV_LINK_MODE=copy: cache mounts are on overlayfs, which doesn't support
+# hardlinks — without this uv warns and falls back per-file.
+# UV_PYTHON_DOWNLOADS=never: use the python:slim base image's interpreter,
+# don't fetch one over the network.
+ENV UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
 
-# Install the package with all dependencies using uv
-RUN uv pip install --system --no-cache .
+# Layer 1: install LOCKED dependencies only, without the project itself.
+# This layer is cached until uv.lock or pyproject.toml changes; src/
+# edits don't invalidate it.
+COPY pyproject.toml uv.lock README.md ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
+
+# Layer 2: install the project itself, non-editable. Cheap layer — the
+# deps are already in the venv from above.
+COPY src/ ./src/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-editable --no-dev
 
 # Runtime stage
 FROM python:${PYTHON_VERSION}-slim AS runtime
 
-ARG PYTHON_VERSION=3.14
-
 WORKDIR /app
 
-# Copy installed packages from builder stage
-COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/site-packages /usr/local/lib/python${PYTHON_VERSION}/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+# Copy the venv built above (same /app/.venv path in both stages — see
+# the WORKDIR comment in the builder). Putting bin/ on PATH makes
+# installed entry points (uvicorn etc.) resolve naturally; the CMD
+# below is unchanged from the pre-venv image.
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 # Run as non-root user
 RUN useradd --system --no-create-home appuser


### PR DESCRIPTION
The previous `uv pip install --system --no-cache .` re-resolved fresh from PyPI every build, making production a third independent resolve alongside `stravapipe.lock` (Pants/CI) and `uv.lock` (local dev). Pin production to `uv.lock` via the canonical uv-docker pattern:

- Multi-stage build with a `--mount=type=cache,target=/root/.cache/uv` cache mount (UV_LINK_MODE=copy for overlayfs).
- Layer 1: `uv sync --frozen --no-install-project --no-dev` — installs locked deps only; cached until uv.lock or pyproject.toml changes.
- Layer 2: `uv sync --frozen --no-editable --no-dev` — installs the project itself, cheap layer that invalidates only on src/ edits.
- Switched from system-Python install to a venv at `/app/.venv` (PATH-prepended); existing `uvicorn` CMD is unchanged.
- Same `WORKDIR /app` in both stages so the venv path matches end-to- end. Without this, uv-generated entry-point scripts bake the builder path into their shebang and `exec uvicorn` fails with "no such file or directory" at runtime — caught during local smoke tests.

`packages/stravapipe/BUILD` adds `uv.lock` to `docker_sources` so it's in the build context.