### PR TITLE
fix(web): harden Firestore writes and align Goal type with proto

### DIFF
--- a/packages/web/src/components/GoalControls.test.tsx
+++ b/packages/web/src/components/GoalControls.test.tsx
@@ -2,12 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import GoalControls from "./GoalControls";
 import type { Goals } from "../utils/goalCalculations";
+import { testGoals } from "../utils/goalTestFixtures";
 
 describe("GoalControls", () => {
-  const mockGoals: Goals = [
+  const mockGoals: Goals = testGoals([
     { id: "1", value: 1000, label: "Base" },
     { id: "2", value: 2000, label: "Target" },
-  ];
+  ]);
 
   // Create async mock that resolves immediately by default
   const createAsyncMock = () => vi.fn().mockResolvedValue(undefined);
@@ -19,6 +20,7 @@ describe("GoalControls", () => {
     currentDistance: 1500,
     unit: "miles" as const,
     sport: "cycling",
+    primaryMetric: "distance_meters",
   };
 
   beforeEach(() => {

--- a/packages/web/src/components/GoalControls.test.tsx
+++ b/packages/web/src/components/GoalControls.test.tsx
@@ -278,4 +278,52 @@ describe("GoalControls", () => {
       expect(screen.queryByLabelText("Dismiss")).not.toBeInTheDocument();
     });
   });
+
+  describe("Reset button", () => {
+    // Pin sport-specific reset behavior. Earlier code defaulted granularity to
+    // 100 for every sport, which produced cycling-shaped goals (e.g. 2400/2500/2600)
+    // even on running and yoga. The fix routes through getMetricConfig(sport).
+    it("produces running-shaped goals when reset on a running page", () => {
+      const onGoalsChange = createAsyncMock();
+      render(
+        <GoalControls
+          {...defaultProps}
+          sport="running"
+          primaryMetric="distance_meters"
+          estimatedYearEnd={0}
+          onGoalsChange={onGoalsChange}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+      // Running config: roundingFactor=10, defaultGoalValue=1000.
+      // Expect: Conservative 990, Target 1000, Stretch 1010.
+      const saved = onGoalsChange.mock.calls[0]![0] as Goals;
+      expect(saved.map((g) => g.value)).toEqual([990, 1000, 1010]);
+      saved.forEach((goal) => {
+        expect(goal.metric).toBe("distance_meters");
+        expect(goal.createdAt).toEqual(expect.any(String));
+      });
+    });
+
+    it("produces cycling-shaped goals when reset on a cycling page", () => {
+      const onGoalsChange = createAsyncMock();
+      render(
+        <GoalControls
+          {...defaultProps}
+          sport="cycling"
+          estimatedYearEnd={0}
+          onGoalsChange={onGoalsChange}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+      // Cycling config: roundingFactor=100, defaultGoalValue=2500.
+      // Expect: Conservative 2400, Target 2500, Stretch 2600.
+      const saved = onGoalsChange.mock.calls[0]![0] as Goals;
+      expect(saved.map((g) => g.value)).toEqual([2400, 2500, 2600]);
+    });
+  });
 });

--- a/packages/web/src/components/GoalControls.tsx
+++ b/packages/web/src/components/GoalControls.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { type Goals, validateGoals, generateDefaultGoals } from "../utils/goalCalculations";
 import { GOAL_COLORS } from "../constants/chartColors";
+import { getMetricConfig } from "../config/metricConfig";
 import type { MetricUnit } from "../utils/units";
 import { useGoalManager } from "../hooks/useGoalManager";
 import { InlineAlert } from "./InlineAlert";
@@ -197,13 +198,21 @@ const GoalControls: React.FC<GoalControlsProps> = ({
         </button>
         <button
           className="btn btn-sm btn-ghost-slate flex items-center justify-center gap-1"
-          onClick={() =>
+          onClick={() => {
+            // Use the sport's own roundingFactor + defaultGoalValue so reset
+            // produces sport-appropriate buckets (running: 10/1000, yoga: 10/100,
+            // cycling: 100/2500). Defaulting both to 100 here silently broke
+            // reset for non-cycling sports — caught in PR review.
+            const metricConfig = getMetricConfig(sport);
             void saveGoals(
-              generateDefaultGoals(estimatedYearEnd, undefined, undefined, {
-                metric: primaryMetric,
-              })
-            )
-          }
+              generateDefaultGoals(
+                estimatedYearEnd,
+                metricConfig.roundingFactor,
+                metricConfig.defaultGoalValue,
+                { metric: primaryMetric }
+              )
+            );
+          }}
           disabled={isSaving}
         >
           <svg

--- a/packages/web/src/components/GoalControls.tsx
+++ b/packages/web/src/components/GoalControls.tsx
@@ -13,6 +13,12 @@ interface GoalControlsProps {
   unit: MetricUnit;
   /** Sport key (e.g., "cycling", "running", "yoga") — drives metric config lookup. */
   sport: string;
+  /**
+   * Sport's primary metric (e.g. "distance_meters"). Required so newly-added
+   * and reset goals carry the correct `metric` from creation — see
+   * harden-user-config-goal-data-integrity #2.
+   */
+  primaryMetric: string;
   // Loading/error state from parent (useUserConfig hook)
   isSaving?: boolean | undefined;
   saveError?: Error | null | undefined;
@@ -25,6 +31,7 @@ const GoalControls: React.FC<GoalControlsProps> = ({
   estimatedYearEnd,
   unit,
   sport,
+  primaryMetric,
   isSaving = false,
   saveError = null,
   onClearSaveError,
@@ -54,6 +61,7 @@ const GoalControls: React.FC<GoalControlsProps> = ({
     onGoalsChange,
     estimatedYearEnd,
     sport,
+    primaryMetric,
   });
 
   const validation = validateGoals(goals);
@@ -189,7 +197,13 @@ const GoalControls: React.FC<GoalControlsProps> = ({
         </button>
         <button
           className="btn btn-sm btn-ghost-slate flex items-center justify-center gap-1"
-          onClick={() => void saveGoals(generateDefaultGoals(estimatedYearEnd))}
+          onClick={() =>
+            void saveGoals(
+              generateDefaultGoals(estimatedYearEnd, undefined, undefined, {
+                metric: primaryMetric,
+              })
+            )
+          }
           disabled={isSaving}
         >
           <svg

--- a/packages/web/src/components/GoalSummaryTable.test.tsx
+++ b/packages/web/src/components/GoalSummaryTable.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import GoalSummaryTable from "./GoalSummaryTable";
 import type { Goals } from "../utils/goalCalculations";
+import { testGoal, testGoals } from "../utils/goalTestFixtures";
 import { createYearContext } from "../utils/yearContext";
 
 // useDangerThresholds pulls from useUserConfig/useAuth at runtime, which require
@@ -34,11 +35,11 @@ describe("GoalSummaryTable", () => {
     vi.useRealTimers();
   });
 
-  const baseGoals: Goals = [
+  const baseGoals: Goals = testGoals([
     { id: "1", value: 1000, label: "Conservative" },
     { id: "2", value: 2000, label: "Target" },
     { id: "3", value: 3000, label: "Stretch" },
-  ];
+  ]);
 
   describe("Rendering", () => {
     it("renders table with all goals", () => {
@@ -78,7 +79,7 @@ describe("GoalSummaryTable", () => {
     it("uses provided unit label", () => {
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 100, label: "Yoga Goal" }]}
+          goals={testGoals([{ id: "1", value: 100, label: "Yoga Goal" }])}
           currentValue={50}
           yearContext={createYearContext(2025)}
           unit="sessions"
@@ -91,11 +92,11 @@ describe("GoalSummaryTable", () => {
     });
 
     it("sorts goals by value", () => {
-      const unsortedGoals: Goals = [
+      const unsortedGoals: Goals = testGoals([
         { id: "1", value: 3000, label: "Third" },
         { id: "2", value: 1000, label: "First" },
         { id: "3", value: 2000, label: "Second" },
-      ];
+      ]);
 
       const { container } = render(
         <GoalSummaryTable
@@ -118,7 +119,7 @@ describe("GoalSummaryTable", () => {
     it("calculates progress percentage correctly", () => {
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 2000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 2000, label: "Test Goal" }])}
           currentValue={1000}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -133,7 +134,7 @@ describe("GoalSummaryTable", () => {
     it("caps progress at 100%", () => {
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={1500}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -149,7 +150,7 @@ describe("GoalSummaryTable", () => {
     it("calculates remaining distance correctly", () => {
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 2000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 2000, label: "Test Goal" }])}
           currentValue={1500}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -164,7 +165,7 @@ describe("GoalSummaryTable", () => {
     it("shows 0 remaining when goal is exceeded", () => {
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={1500}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -189,7 +190,7 @@ describe("GoalSummaryTable", () => {
     it('shows "Achieved" with check icon for completed goals', () => {
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={1000}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -205,7 +206,7 @@ describe("GoalSummaryTable", () => {
       // Need 454 * 1.1 = 500+ miles for "Ahead"
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={550}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -221,7 +222,7 @@ describe("GoalSummaryTable", () => {
       // Pace ratio 0.9-1.1 = 409-499 miles
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={450}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -237,7 +238,7 @@ describe("GoalSummaryTable", () => {
       // Pace ratio 0.75-0.9 = 341-408 miles
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={370}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -253,7 +254,7 @@ describe("GoalSummaryTable", () => {
       // Pace ratio 0.5-0.75 = 227-340 miles
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={280}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -269,7 +270,7 @@ describe("GoalSummaryTable", () => {
       // Pace ratio < 0.5 = less than 227 miles
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={100}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -288,7 +289,7 @@ describe("GoalSummaryTable", () => {
       // Pace needed: 4100 / 200 = 20.5 mi/day (exceeds threshold)
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 4100, label: "Dangerous Goal" }]}
+          goals={testGoals([{ id: "1", value: 4100, label: "Dangerous Goal" }])}
           currentValue={0}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -306,7 +307,7 @@ describe("GoalSummaryTable", () => {
       // Pace needed: 2100 / 200 = 10.5 mi/day (exceeds threshold)
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 2100, label: "Dangerous Goal" }]}
+          goals={testGoals([{ id: "1", value: 2100, label: "Dangerous Goal" }])}
           currentValue={0}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -324,7 +325,7 @@ describe("GoalSummaryTable", () => {
       // Pace needed: 24100 / 200 = 120.5 min/day (exceeds threshold)
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 24100, label: "Dangerous Goal" }]}
+          goals={testGoals([{ id: "1", value: 24100, label: "Dangerous Goal" }])}
           currentValue={0}
           yearContext={createYearContext(2025)}
           unit="minutes"
@@ -341,7 +342,7 @@ describe("GoalSummaryTable", () => {
       // Pace needed: 1000 / 200 = 5 mi/day (safe for cycling)
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Safe Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Safe Goal" }])}
           currentValue={0}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -356,7 +357,7 @@ describe("GoalSummaryTable", () => {
     it("shows warning icon for dangerous goals", () => {
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 4100, label: "Dangerous Goal" }]}
+          goals={testGoals([{ id: "1", value: 4100, label: "Dangerous Goal" }])}
           currentValue={0}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -371,7 +372,7 @@ describe("GoalSummaryTable", () => {
     it("shows warning banner when dangerous goals exist", () => {
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 4100, label: "Dangerous Goal" }]}
+          goals={testGoals([{ id: "1", value: 4100, label: "Dangerous Goal" }])}
           currentValue={0}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -389,7 +390,7 @@ describe("GoalSummaryTable", () => {
     it("does not show warning banner when all goals are safe", () => {
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Safe Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Safe Goal" }])}
           currentValue={0}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -405,7 +406,7 @@ describe("GoalSummaryTable", () => {
     it("shows daily pace column for current year", () => {
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 2000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 2000, label: "Test Goal" }])}
           currentValue={1000}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -419,7 +420,7 @@ describe("GoalSummaryTable", () => {
     it("hides daily pace column for past years", () => {
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 2000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 2000, label: "Test Goal" }])}
           currentValue={1000}
           yearContext={createYearContext(2024)}
           unit="miles"
@@ -436,7 +437,7 @@ describe("GoalSummaryTable", () => {
       // Pace needed: 1000 / 200 = 5.0 mi/day
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 2000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 2000, label: "Test Goal" }])}
           currentValue={1000}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -451,7 +452,7 @@ describe("GoalSummaryTable", () => {
     it("shows 0 pace when goal is already achieved", () => {
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={1500}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -505,7 +506,7 @@ describe("GoalSummaryTable", () => {
     it("handles goals with no label", () => {
       render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000 }]}
+          goals={[testGoal({ id: "1", value: 1000, label: "" })]}
           currentValue={500}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -519,7 +520,7 @@ describe("GoalSummaryTable", () => {
     it("handles zero current distance", () => {
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 1000, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 1000, label: "Test Goal" }])}
           currentValue={0}
           yearContext={createYearContext(2025)}
           unit="miles"
@@ -535,7 +536,7 @@ describe("GoalSummaryTable", () => {
     it("handles zero goal value", () => {
       const { container } = render(
         <GoalSummaryTable
-          goals={[{ id: "1", value: 0, label: "Test Goal" }]}
+          goals={testGoals([{ id: "1", value: 0, label: "Test Goal" }])}
           currentValue={0}
           yearContext={createYearContext(2025)}
           unit="miles"

--- a/packages/web/src/components/SportPageContent.test.tsx
+++ b/packages/web/src/components/SportPageContent.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/react";
 import SportPageContent, { type SportPageContentProps } from "./SportPageContent";
 import { createYearContext } from "../utils/yearContext";
+import { testGoal, testGoals } from "../utils/goalTestFixtures";
 import { renderWithRouter } from "../test/renderWithRouter";
 
 // Mock heavy chart components to keep tests fast and focused on layout logic
@@ -69,18 +70,19 @@ const baseProps: SportPageContentProps = {
   isLoading: false,
   error: null,
   unit: "miles",
-  goals: [
+  primaryMetric: "distance_meters",
+  goals: testGoals([
     { id: "1", value: 1000, label: "Conservative" },
     { id: "2", value: 2000, label: "Target" },
-  ],
-  chartGoals: [
+  ]),
+  chartGoals: testGoals([
     { id: "1", value: 1000, label: "Conservative" },
     { id: "2", value: 2000, label: "Target" },
-  ],
+  ]),
   onGoalsChange: vi.fn(),
   isGoalsSaving: false,
   goalsSaveError: null,
-  nextGoal: { id: "1", value: 1000, label: "Conservative" },
+  nextGoal: testGoal({ id: "1", value: 1000, label: "Conservative" }),
   nextGoalProgress: 30,
   nextGoalGap: 700,
   paceNeededForNextGoal: 2.5,

--- a/packages/web/src/components/SportPageContent.tsx
+++ b/packages/web/src/components/SportPageContent.tsx
@@ -36,6 +36,11 @@ export interface SportPageContentProps {
   // Units
   unit: MetricUnit;
 
+  // Sport metrics
+  /** Sport's primary metric — passed to GoalControls so newly-added goals
+   * carry the right `metric` from creation. */
+  primaryMetric: string;
+
   // Goals
   goals: Goals;
   /** Goals to pass to charts (pre-filtered: empty when not viewing primary metric) */
@@ -88,6 +93,7 @@ export default function SportPageContent({
   error,
   onRetry,
   unit,
+  primaryMetric,
   goals,
   chartGoals,
   onGoalsChange,
@@ -156,6 +162,7 @@ export default function SportPageContent({
               estimatedYearEnd={estimatedYearEnd}
               unit={unit}
               sport={sport}
+              primaryMetric={primaryMetric}
               isSaving={isGoalsSaving}
               saveError={goalsSaveError}
               onClearSaveError={onClearGoalsSaveError}

--- a/packages/web/src/hooks/useCumulativeChartData.test.ts
+++ b/packages/web/src/hooks/useCumulativeChartData.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { useCumulativeChartData } from "./useCumulativeChartData";
+import { testGoals } from "../utils/goalTestFixtures";
 
 // Stub user-config-backed dependencies that useDangerThresholds pulls in.
 vi.mock("./useUserConfig", () => ({
@@ -30,7 +31,7 @@ vi.mock("./usePublicSportConfig", () => ({
 
 describe("useCumulativeChartData", () => {
   const year = 2024;
-  const goals = [{ id: "1", value: 1000, label: "Goal 1" }];
+  const goals = testGoals([{ id: "1", value: 1000, label: "Goal 1" }]);
   const distanceData = [
     { x: "2024-01-01T00:00:00Z", y: 10 },
     { x: "2024-01-02T00:00:00Z", y: 20 },

--- a/packages/web/src/hooks/useGoalManager.test.ts
+++ b/packages/web/src/hooks/useGoalManager.test.ts
@@ -1,18 +1,21 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { useGoalManager } from "./useGoalManager";
+import { testGoals } from "../utils/goalTestFixtures";
+import type { Goal } from "../utils/goalCalculations";
 
 describe("useGoalManager", () => {
-  const initialGoals = [
+  const initialGoals = testGoals([
     { id: "1", value: 1000, label: "Goal 1" },
     { id: "2", value: 2000, label: "Goal 2" },
-  ];
+  ]);
   const onGoalsChange = vi.fn().mockResolvedValue(undefined);
   const defaultProps = {
     goals: initialGoals,
     onGoalsChange,
     estimatedYearEnd: 3000,
     sport: "cycling",
+    primaryMetric: "distance_meters",
   };
 
   beforeEach(() => {
@@ -37,10 +40,33 @@ describe("useGoalManager", () => {
       result.current.handleIncrement("1", 100);
     });
 
-    expect(onGoalsChange).toHaveBeenCalledWith([
-      { id: "1", value: 1100, label: "Goal 1" },
-      { id: "2", value: 2000, label: "Goal 2" },
+    expect(onGoalsChange).toHaveBeenCalledTimes(1);
+    const saved = onGoalsChange.mock.calls[0]![0] as Goal[];
+    expect(saved).toHaveLength(2);
+    expect(saved[0]!.id).toBe("1");
+    expect(saved[0]!.value).toBe(1100);
+    expect(saved[1]!.id).toBe("2");
+    expect(saved[1]!.value).toBe(2000);
+  });
+
+  it("should bump updatedAt on the mutated goal but leave siblings untouched", async () => {
+    const original = testGoals([
+      { id: "1", value: 1000, label: "Goal 1", createdAt: "2024-06-01T00:00:00.000Z" },
+      { id: "2", value: 2000, label: "Goal 2", createdAt: "2024-06-01T00:00:00.000Z" },
     ]);
+    const { result } = renderHook(() => useGoalManager({ ...defaultProps, goals: original }));
+
+    await act(async () => {
+      result.current.handleIncrement("1", 100);
+    });
+
+    const saved = onGoalsChange.mock.calls[0]![0] as Goal[];
+    // Goal 1 was mutated → updatedAt is fresh (not the fixture stamp).
+    expect(saved[0]!.updatedAt).not.toBe("2025-01-01T00:00:00.000Z");
+    expect(saved[0]!.createdAt).toBe("2024-06-01T00:00:00.000Z");
+    // Goal 2 was untouched → both timestamps unchanged.
+    expect(saved[1]!.updatedAt).toBe(original[1]!.updatedAt);
+    expect(saved[1]!.createdAt).toBe("2024-06-01T00:00:00.000Z");
   });
 
   it("should handle starting edit", () => {
@@ -72,10 +98,9 @@ describe("useGoalManager", () => {
       result.current.handleSaveEdit("1");
     });
 
-    expect(onGoalsChange).toHaveBeenCalledWith([
-      { id: "1", value: 1500, label: "Goal 1" },
-      { id: "2", value: 2000, label: "Goal 2" },
-    ]);
+    const saved = onGoalsChange.mock.calls[0]![0] as Goal[];
+    expect(saved[0]!.value).toBe(1500);
+    expect(saved[1]!.value).toBe(2000);
     expect(result.current.editingId).toBeNull();
   });
 
@@ -96,21 +121,45 @@ describe("useGoalManager", () => {
 
     expect(result.current.editValidationError).not.toBeNull();
     expect(onGoalsChange).not.toHaveBeenCalledWith(
-      expect.arrayContaining([{ id: "1", value: -100 }])
+      expect.arrayContaining([expect.objectContaining({ id: "1", value: -100 })])
     );
   });
 
-  it("should handle adding a goal", async () => {
+  it("should handle adding a goal with full proto metadata", async () => {
     const { result } = renderHook(() => useGoalManager(defaultProps));
 
     await act(async () => {
       result.current.handleAddGoal();
     });
 
-    expect(onGoalsChange).toHaveBeenCalled();
-    const callArgs = onGoalsChange.mock.calls[0]![0];
+    expect(onGoalsChange).toHaveBeenCalledTimes(1);
+    const callArgs = onGoalsChange.mock.calls[0]![0] as Goal[];
     expect(callArgs).toHaveLength(3);
-    expect(callArgs[2]!.label).toBe("Goal 3");
+
+    const newGoal = callArgs[2]!;
+    // The added goal must carry every proto field — no later code path can
+    // "bolt on" missing fields. This is the core invariant from #2.
+    expect(newGoal.id).toEqual(expect.any(String));
+    expect(newGoal.value).toEqual(expect.any(Number));
+    expect(newGoal.label).toBe("Goal 3");
+    expect(newGoal.metric).toBe("distance_meters");
+    expect(newGoal.createdAt).toEqual(expect.any(String));
+    expect(newGoal.updatedAt).toEqual(expect.any(String));
+    // ISO timestamps should be roughly now.
+    expect(new Date(newGoal.createdAt).getTime()).toBeGreaterThan(Date.now() - 5_000);
+  });
+
+  it("should respect primaryMetric when adding a goal", async () => {
+    const { result } = renderHook(() =>
+      useGoalManager({ ...defaultProps, primaryMetric: "time_minutes" })
+    );
+
+    await act(async () => {
+      result.current.handleAddGoal();
+    });
+
+    const saved = onGoalsChange.mock.calls[0]![0] as Goal[];
+    expect(saved[2]!.metric).toBe("time_minutes");
   });
 
   it("should handle removing a goal", async () => {
@@ -120,7 +169,9 @@ describe("useGoalManager", () => {
       result.current.handleRemoveGoal("1");
     });
 
-    expect(onGoalsChange).toHaveBeenCalledWith([{ id: "2", value: 2000, label: "Goal 2" }]);
+    const saved = onGoalsChange.mock.calls[0]![0] as Goal[];
+    expect(saved).toHaveLength(1);
+    expect(saved[0]!.id).toBe("2");
   });
 
   it("should handle save errors", async () => {
@@ -167,10 +218,10 @@ describe("useGoalManager", () => {
     // Should call save for both edits
     expect(onGoalsChange).toHaveBeenCalledTimes(2);
     expect(onGoalsChange).toHaveBeenCalledWith(
-      expect.arrayContaining([{ id: "1", value: 1000, label: "Updated 1" }])
+      expect.arrayContaining([expect.objectContaining({ id: "1", label: "Updated 1" })])
     );
     expect(onGoalsChange).toHaveBeenCalledWith(
-      expect.arrayContaining([{ id: "2", value: 2000, label: "Updated 2" }])
+      expect.arrayContaining([expect.objectContaining({ id: "2", label: "Updated 2" })])
     );
 
     vi.useRealTimers();

--- a/packages/web/src/hooks/useGoalManager.ts
+++ b/packages/web/src/hooks/useGoalManager.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useMemo, useCallback } from "react";
-import { type Goals, type Goal, validateGoalValue } from "../utils/goalCalculations";
+import { type Goals, type Goal, buildGoal, validateGoalValue } from "../utils/goalCalculations";
 import { getMetricConfig } from "../config/metricConfig";
 import { logApiError } from "../api/errors";
 
@@ -8,6 +8,13 @@ interface UseGoalManagerProps {
   onGoalsChange: (goals: Goals) => Promise<void>;
   estimatedYearEnd: number;
   sport: string;
+  /**
+   * Sport's primary metric (e.g. "distance_meters"). Required so newly-added
+   * goals carry the right `metric` from the moment of creation — closes the
+   * "where does metric come from?" gap from issue #2 of
+   * harden-user-config-goal-data-integrity.
+   */
+  primaryMetric: string;
 }
 
 /**
@@ -26,6 +33,7 @@ export function useGoalManager({
   onGoalsChange,
   estimatedYearEnd,
   sport,
+  primaryMetric,
 }: UseGoalManagerProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
@@ -71,7 +79,8 @@ export function useGoalManager({
   const handleGoalValueChange = (id: string, value: number) => {
     // Round based on sport type (100 for cycling, 10 for running/yoga)
     const rounded = Math.round(value / roundingFactor) * roundingFactor;
-    const updated = goals.map((g) => (g.id === id ? { ...g, value: rounded } : g));
+    const now = new Date().toISOString();
+    const updated = goals.map((g) => (g.id === id ? { ...g, value: rounded, updatedAt: now } : g));
     void saveGoals(updated);
   };
 
@@ -104,7 +113,8 @@ export function useGoalManager({
     }
 
     // Don't round manual text entry - allow any positive integer
-    const updated = goals.map((g) => (g.id === id ? { ...g, value } : g));
+    const now = new Date().toISOString();
+    const updated = goals.map((g) => (g.id === id ? { ...g, value, updatedAt: now } : g));
     void saveGoals(updated);
     setEditingId(null);
     setEditValidationError(null);
@@ -113,7 +123,8 @@ export function useGoalManager({
   const handleGoalLabelChange = (id: string, label: string) => {
     // Use goalsRef to ensure we work with latest state in async callbacks
     const currentGoals = goalsRef.current;
-    const updated = currentGoals.map((g) => (g.id === id ? { ...g, label } : g));
+    const now = new Date().toISOString();
+    const updated = currentGoals.map((g) => (g.id === id ? { ...g, label, updatedAt: now } : g));
     void saveGoals(updated);
   };
 
@@ -160,11 +171,15 @@ export function useGoalManager({
       newValue += incrementSize;
     }
 
-    const newGoal: Goal = {
+    // Stamp full proto metadata at creation. Centralising this in buildGoal
+    // (and threading `primaryMetric` as a prop) closes the "partial goal"
+    // gap from harden-user-config-goal-data-integrity #2.
+    const newGoal: Goal = buildGoal({
       id: Date.now().toString(),
       value: newValue,
       label: `Goal ${goals.length + 1}`,
-    };
+      metric: primaryMetric,
+    });
     void saveGoals([...goals, newGoal]);
   };
 

--- a/packages/web/src/hooks/useGoalStats.test.ts
+++ b/packages/web/src/hooks/useGoalStats.test.ts
@@ -2,19 +2,21 @@ import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useGoalStats } from "./useGoalStats";
 import type { Goal } from "../utils/goalCalculations";
+import { testGoals } from "../utils/goalTestFixtures";
 
 describe("useGoalStats", () => {
-  const createGoals = (): Goal[] => [
-    { id: "1", value: 1000, label: "Base" },
-    { id: "2", value: 2000, label: "Challenger" },
-    { id: "3", value: 3000, label: "Elite" },
-  ];
+  const createGoals = (): Goal[] =>
+    testGoals([
+      { id: "1", value: 1000, label: "Base" },
+      { id: "2", value: 2000, label: "Challenger" },
+      { id: "3", value: 3000, label: "Elite" },
+    ]);
 
   it("finds next goal when current distance is below first goal", () => {
     const goals = createGoals();
     const { result } = renderHook(() => useGoalStats(goals, 500, 70));
 
-    expect(result.current.nextGoal).toEqual({ id: "1", value: 1000, label: "Base" });
+    expect(result.current.nextGoal).toMatchObject({ id: "1", value: 1000, label: "Base" });
     expect(result.current.nextGoalProgress).toBe(50); // 500/1000 * 100
     expect(result.current.nextGoalGap).toBe(500);
   });
@@ -23,7 +25,7 @@ describe("useGoalStats", () => {
     const goals = createGoals();
     const { result } = renderHook(() => useGoalStats(goals, 1500, 70));
 
-    expect(result.current.nextGoal).toEqual({ id: "2", value: 2000, label: "Challenger" });
+    expect(result.current.nextGoal).toMatchObject({ id: "2", value: 2000, label: "Challenger" });
     expect(result.current.nextGoalProgress).toBe(75); // 1500/2000 * 100
     expect(result.current.nextGoalGap).toBe(500);
   });
@@ -32,7 +34,7 @@ describe("useGoalStats", () => {
     const goals = createGoals();
     const { result } = renderHook(() => useGoalStats(goals, 3500, 70));
 
-    expect(result.current.nextGoal).toEqual({ id: "3", value: 3000, label: "Elite" });
+    expect(result.current.nextGoal).toMatchObject({ id: "3", value: 3000, label: "Elite" });
     expect(result.current.nextGoalProgress).toBeGreaterThan(100); // 3500/3000 * 100 = 116.67
     expect(result.current.nextGoalGap).toBe(0); // No gap when goal is passed
   });
@@ -74,7 +76,7 @@ describe("useGoalStats", () => {
     const { result } = renderHook(() => useGoalStats(goals, 2000, 70));
 
     // Exactly at Challenger goal
-    expect(result.current.nextGoal).toEqual({ id: "3", value: 3000, label: "Elite" });
+    expect(result.current.nextGoal).toMatchObject({ id: "3", value: 3000, label: "Elite" });
     expect(result.current.nextGoalProgress).toBe(66.66666666666666); // 2000/3000 * 100
     expect(result.current.nextGoalGap).toBe(1000);
   });
@@ -91,9 +93,10 @@ describe("useGoalStats", () => {
     expect(result.current.nextGoal?.label).toBe("Challenger");
 
     // Add a new goal between current distance and next goal
-    const newGoals = [...goals, { id: "4", value: 1800, label: "Intermediate" }].sort(
-      (a, b) => a.value - b.value
-    );
+    const newGoals = [
+      ...goals,
+      ...testGoals([{ id: "4", value: 1800, label: "Intermediate" }]),
+    ].sort((a, b) => a.value - b.value);
 
     rerender({ goals: newGoals, distance: 1500, days: 70 });
 
@@ -135,15 +138,15 @@ describe("useGoalStats", () => {
   });
 
   it("handles single goal", () => {
-    const goals: Goal[] = [{ id: "1", value: 2000, label: "Only Goal" }];
+    const goals: Goal[] = testGoals([{ id: "1", value: 2000, label: "Only Goal" }]);
     const { result } = renderHook(() => useGoalStats(goals, 1500, 70));
 
-    expect(result.current.nextGoal).toEqual({ id: "1", value: 2000, label: "Only Goal" });
+    expect(result.current.nextGoal).toMatchObject({ id: "1", value: 2000, label: "Only Goal" });
     expect(result.current.nextGoalProgress).toBe(75);
   });
 
   it("handles progress over 100%", () => {
-    const goals: Goal[] = [{ id: "1", value: 1000, label: "Goal" }];
+    const goals: Goal[] = testGoals([{ id: "1", value: 1000, label: "Goal" }]);
     const { result } = renderHook(() => useGoalStats(goals, 1500, 70));
 
     expect(result.current.nextGoalProgress).toBe(150);

--- a/packages/web/src/hooks/usePacingChartData.test.ts
+++ b/packages/web/src/hooks/usePacingChartData.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { usePacingChartData } from "./usePacingChartData";
+import { testGoals } from "../utils/goalTestFixtures";
 
 // Mock dependencies
 vi.mock("./useUserConfig", () => ({
@@ -37,10 +38,10 @@ vi.mock("./usePublicSportConfig", () => ({
 describe("usePacingChartData", () => {
   // Test fixtures
   const year = 2024;
-  const goals = [
+  const goals = testGoals([
     { id: "1", value: 3000, label: "Base Goal" },
     { id: "2", value: 5000, label: "Stretch Goal" },
-  ];
+  ]);
   const distanceData = [
     { x: "2024-01-01T00:00:00Z", y: 10 },
     { x: "2024-01-02T00:00:00Z", y: 25 },
@@ -223,7 +224,7 @@ describe("usePacingChartData", () => {
       const { result } = renderHook(() =>
         usePacingChartData({
           year: 2024,
-          goals: [{ id: "1", value: 36600, label: "Extreme" }], // Requires 100/day
+          goals: testGoals([{ id: "1", value: 36600, label: "Extreme" }]), // Requires 100/day
           distanceData: [{ x: "2024-01-01T00:00:00Z", y: 10 }],
           showFullYear: true,
           sport: "cycling",
@@ -241,7 +242,7 @@ describe("usePacingChartData", () => {
       const { result } = renderHook(() =>
         usePacingChartData({
           year: 2024,
-          goals: [{ id: "1", value: 3660, label: "Easy" }], // Requires 10/day
+          goals: testGoals([{ id: "1", value: 3660, label: "Easy" }]), // Requires 10/day
           distanceData: [{ x: "2024-01-01T00:00:00Z", y: 25 }],
           showFullYear: true,
           sport: "cycling",
@@ -260,7 +261,7 @@ describe("usePacingChartData", () => {
       const { result } = renderHook(() =>
         usePacingChartData({
           year: 2024,
-          goals: [{ id: "1", value: 1800, label: "Easy" }], // ~5/day
+          goals: testGoals([{ id: "1", value: 1800, label: "Easy" }]), // ~5/day
           distanceData: [{ x: "2024-01-01T00:00:00Z", y: 3 }],
           showFullYear: true,
           sport: "cycling",
@@ -276,7 +277,7 @@ describe("usePacingChartData", () => {
       const { result } = renderHook(() =>
         usePacingChartData({
           year: 2024,
-          goals: [{ id: "1", value: 6588, label: "Stretch" }], // ~18/day
+          goals: testGoals([{ id: "1", value: 6588, label: "Stretch" }]), // ~18/day
           distanceData: [{ x: "2024-01-01T00:00:00Z", y: 3 }],
           showFullYear: true,
           sport: "cycling",

--- a/packages/web/src/hooks/useSportPageData.ts
+++ b/packages/web/src/hooks/useSportPageData.ts
@@ -68,6 +68,11 @@ export interface SportPageData {
   // Units
   unit: MetricUnit;
 
+  // Sport metrics
+  /** Sport's primary metric (e.g. "distance_meters"). Required by GoalControls
+   * so newly-added goals carry the right `metric` from creation. */
+  primaryMetric: string;
+
   // Goals
   goals: Goals;
   chartGoals: Goals;
@@ -217,19 +222,26 @@ export function useSportPageData(sport: string, year: number): SportPageData {
   // perpetually unstable, causing useUserConfig to re-trigger on every render.
   const defaultGoalsForYear: GoalsForYear = useMemo(() => {
     const { roundingFactor, defaultGoalValue } = primaryMetricConfig;
-    const generatedGoals = generateDefaultGoals(estimatedYearEnd, roundingFactor, defaultGoalValue);
     const now = new Date().toISOString();
     const goalMetric = getPrimaryMetric(sport, sportConfig);
+    // generateDefaultGoals now stamps metric/createdAt/updatedAt itself, so the
+    // map below only converts display→storage units.
+    const generatedGoals = generateDefaultGoals(
+      estimatedYearEnd,
+      roundingFactor,
+      defaultGoalValue,
+      { metric: goalMetric, now }
+    );
     const ctx: GoalUnitContext = { hasDistance, isTime, distanceUnit };
 
     return {
       goals: generatedGoals.map((goal) => ({
         id: goal.id,
         value: goalToStorage(goal.value, ctx),
-        label: goal.label || "",
-        metric: goalMetric,
-        createdAt: now,
-        updatedAt: now,
+        label: goal.label,
+        metric: goal.metric,
+        createdAt: goal.createdAt,
+        updatedAt: goal.updatedAt,
       })),
       storageVersion: GOAL_STORAGE_VERSION,
     };
@@ -259,9 +271,11 @@ export function useSportPageData(sport: string, year: number): SportPageData {
   useGoalMigration(goalsData, user?.uid ?? "", year, sport, hasDistance, isTime, updateGoals);
 
   // Convert goals from storage units to display units for UI.
-  // Warns once per render if a goal's stored `metric` disagrees with the
-  // sport's primary metric — catches stale data (e.g. a goal copied across
-  // sports, or a primaryMetric config change that left old records behind).
+  // Carries all proto fields through to the display layer so a later write
+  // doesn't need to re-derive metric/createdAt/updatedAt — closes the bolt-on
+  // gap from harden-user-config-goal-data-integrity #2. Still warns once per
+  // render if a goal's `metric` disagrees with the sport's primary metric
+  // (catches stale data, e.g. a goal copied across sports).
   const goalCtx: GoalUnitContext = { hasDistance, isTime, distanceUnit };
   const goals: Goals = goalsData?.goals
     ? goalsData.goals.map((g) => {
@@ -274,24 +288,29 @@ export function useSportPageData(sport: string, year: number): SportPageData {
           id: g.id,
           value: goalToDisplay(g.value, goalCtx),
           label: g.label,
+          metric: g.metric,
+          createdAt: g.createdAt,
+          updatedAt: g.updatedAt,
         };
       })
     : [];
 
-  // Handle goals change: convert from display units back to storage units
-  // No manual useCallback — the React Compiler auto-memoizes this. The new Date()
-  // calls are inside the callback body (lazy), so they don't break memoization.
+  // Handle goals change: pure unit conversion. All proto metadata
+  // (metric/createdAt/updatedAt) is already on each Goal — useGoalManager
+  // stamps it on creation and refreshes `updatedAt` on every mutation. This
+  // hook no longer fabricates fields, which means any code path that calls
+  // updateGoals with malformed data will surface the bug here (and via the
+  // write-side schema guard in UserConfigService) instead of silently
+  // persisting partial records.
   const handleGoalsChange = async (newGoals: Goals) => {
-    const goalMetric = getPrimaryMetric(sport, sportConfig);
     const updatedGoalsForYear: GoalsForYear = {
       goals: newGoals.map((goal) => ({
         id: goal.id,
         value: goalToStorage(goal.value, goalCtx),
-        label: goal.label || "",
-        metric: goalMetric,
-        updatedAt: new Date().toISOString(),
-        createdAt:
-          goalsData?.goals?.find((g) => g.id === goal.id)?.createdAt || new Date().toISOString(),
+        label: goal.label,
+        metric: goal.metric,
+        createdAt: goal.createdAt,
+        updatedAt: goal.updatedAt,
       })),
       storageVersion: GOAL_STORAGE_VERSION,
     };
@@ -322,6 +341,7 @@ export function useSportPageData(sport: string, year: number): SportPageData {
     error,
     retry,
     unit: metricUnit,
+    primaryMetric,
     goals,
     chartGoals: isViewingPrimaryMetric ? goals : [],
     onGoalsChange: handleGoalsChange,

--- a/packages/web/src/pages/DemoSportPage.test.tsx
+++ b/packages/web/src/pages/DemoSportPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import DemoSportPage from "./DemoSportPage";
+import type * as GoalCalcModule from "../utils/goalCalculations";
 import { renderWithRouter } from "../test/renderWithRouter";
 
 const mockNavigate = vi.fn();
@@ -98,13 +99,19 @@ vi.mock("../utils/units", () => ({
   },
 }));
 
-vi.mock("../utils/goalCalculations", () => ({
-  estimateYearEndDistance: () => 1000,
-  // Identity converters keep test fixtures readable; the actual conversion is
-  // exercised in goalCalculations / migration unit tests.
-  goalToStorage: (value: number) => value,
-  goalToDisplay: (value: number) => value,
-}));
+vi.mock("../utils/goalCalculations", async (importOriginal) => {
+  // Keep `buildGoal` (and any other future helpers DemoSportPage imports)
+  // available from the real module; only stub the math we don't care about.
+  const actual = await importOriginal<typeof GoalCalcModule>();
+  return {
+    ...actual,
+    estimateYearEndDistance: () => 1000,
+    // Identity converters keep test fixtures readable; the actual conversion is
+    // exercised in goalCalculations / migration unit tests.
+    goalToStorage: (value: number) => value,
+    goalToDisplay: (value: number) => value,
+  };
+});
 
 // Stub SportPageContent to expose callbacks via test buttons
 vi.mock("../components/SportPageContent", () => ({

--- a/packages/web/src/pages/DemoSportPage.tsx
+++ b/packages/web/src/pages/DemoSportPage.tsx
@@ -3,9 +3,11 @@ import { useNavigate } from "@tanstack/react-router";
 import { useCurrentYear } from "../hooks/useCurrentYear";
 import { getDisplayUnitForMetric, getUserSettings, type MetricUnit } from "../utils/units";
 import {
+  buildGoal,
   estimateYearEndDistance,
   goalToDisplay,
   goalToStorage,
+  type Goal,
   type GoalUnitContext,
   type Goals,
 } from "../utils/goalCalculations";
@@ -93,31 +95,54 @@ export default function DemoSportPage({ sport, year }: DemoSportPageProps) {
     const stored = localStorage.getItem(storageKey);
     if (stored) {
       try {
-        const parsed = JSON.parse(stored) as { goals?: Goals } | null;
+        const parsed = JSON.parse(stored) as { goals?: Partial<Goal>[] } | null;
         if (Array.isArray(parsed?.goals)) {
           // Stored canonical → convert to display for the UI.
-          return parsed.goals.map((g) => ({ ...g, value: goalToDisplay(g.value, goalCtx) }));
+          // Legacy demo payloads may lack proto metadata (pre-#2 fix); fill
+          // defaults so the resulting Goals always satisfy the type.
+          const now = new Date().toISOString();
+          return parsed.goals.map((g) =>
+            buildGoal(
+              {
+                id: g.id ?? now,
+                value: typeof g.value === "number" ? goalToDisplay(g.value, goalCtx) : 0,
+                label: g.label ?? "",
+                metric: g.metric ?? primaryMetric,
+              },
+              g.createdAt ?? now
+            )
+          );
         }
       } catch {
         // Fall back to defaults
       }
     }
+    const now = new Date().toISOString();
     const demoGoals = getDemoGoalsForSport(sport);
     if (demoGoals) {
       // Demo defaults are already in display units — keep them that way for the UI.
       return [
-        { id: "1", value: demoGoals.conservative, label: "Conservative" },
-        { id: "2", value: demoGoals.target, label: "Target" },
-        { id: "3", value: demoGoals.stretch, label: "Stretch" },
+        buildGoal(
+          { id: "1", value: demoGoals.conservative, label: "Conservative", metric: primaryMetric },
+          now
+        ),
+        buildGoal(
+          { id: "2", value: demoGoals.target, label: "Target", metric: primaryMetric },
+          now
+        ),
+        buildGoal(
+          { id: "3", value: demoGoals.stretch, label: "Stretch", metric: primaryMetric },
+          now
+        ),
       ];
     }
     return [
-      { id: "1", value: 2000, label: "Conservative" },
-      { id: "2", value: 2500, label: "Target" },
-      { id: "3", value: 3000, label: "Stretch" },
+      buildGoal({ id: "1", value: 2000, label: "Conservative", metric: primaryMetric }, now),
+      buildGoal({ id: "2", value: 2500, label: "Target", metric: primaryMetric }, now),
+      buildGoal({ id: "3", value: 3000, label: "Stretch", metric: primaryMetric }, now),
     ];
     // goalCtx is derived from sport/userSettings; including them transitively.
-  }, [storageKey, sport, goalCtx]);
+  }, [storageKey, sport, goalCtx, primaryMetric]);
 
   const [goals, setGoals] = useState<Goals>(loadGoals);
   const [prevStorageKey, setPrevStorageKey] = useState(storageKey);
@@ -173,6 +198,7 @@ export default function DemoSportPage({ sport, year }: DemoSportPageProps) {
         isLoading={isLoading}
         error={error}
         unit={metricUnit}
+        primaryMetric={primaryMetric}
         goals={goals}
         chartGoals={goals}
         onGoalsChange={handleGoalsChange}

--- a/packages/web/src/pages/SportPage.tsx
+++ b/packages/web/src/pages/SportPage.tsx
@@ -29,6 +29,7 @@ export default function SportPage({ sport, year }: SportPageProps) {
       error={data.error}
       onRetry={data.retry}
       unit={data.unit}
+      primaryMetric={data.primaryMetric}
       goals={data.goals}
       chartGoals={data.chartGoals}
       onGoalsChange={data.onGoalsChange}

--- a/packages/web/src/services/database/DatabaseService.ts
+++ b/packages/web/src/services/database/DatabaseService.ts
@@ -23,6 +23,26 @@ export interface SubscribeDocumentOptions<T> {
   schema?: z.ZodType<T>;
 }
 
+/**
+ * Options for setDocument
+ */
+export interface SetDocumentOptions<T> {
+  /** When true, shallow-merge `data` into the existing document instead of overwriting. */
+  merge?: boolean;
+  /**
+   * Zod schema for runtime validation. When provided, `data` is validated
+   * **before** the database call — a validation failure throws synchronously
+   * and the write does not happen.
+   *
+   * Mirrors the read-side `GetDocumentOptions.schema` pattern so the same
+   * schema can guard reads and writes. Use this on any setDocument call that
+   * targets a typed collection (e.g. user config) to make malformed writes
+   * fail loudly at the source instead of silently persisting and breaking
+   * later reads.
+   */
+  schema?: z.ZodType<T>;
+}
+
 export interface DatabaseService {
   /**
    * Get a document by path
@@ -36,9 +56,11 @@ export interface DatabaseService {
    * Set a document (creates or overwrites)
    * @param path Document path
    * @param data Document data
-   * @param options Optional settings (merge: true to merge with existing)
+   * @param options Optional settings — `merge` shallow-merges into the
+   *   existing doc; `schema` validates `data` before the write (throws on
+   *   failure, write does not happen).
    */
-  setDocument<T>(path: string, data: T, options?: { merge?: boolean }): Promise<void>;
+  setDocument<T>(path: string, data: T, options?: SetDocumentOptions<T>): Promise<void>;
 
   /**
    * Delete a document

--- a/packages/web/src/services/database/FirestoreService.test.ts
+++ b/packages/web/src/services/database/FirestoreService.test.ts
@@ -1,0 +1,89 @@
+/**
+ * FirestoreService unit tests
+ *
+ * Focused on the write-side validation guard added to close the bug class
+ * from 2026-03-23 (silent bad data persisted because writes were unvalidated).
+ * The read-side validation path is exercised end-to-end via `userConfigService`
+ * tests; here we pin the *write*-side throw-before-write behavior.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+import { FirestoreService } from "./FirestoreService";
+import * as firestore from "firebase/firestore";
+
+vi.mock("firebase/app", () => ({
+  initializeApp: vi.fn(() => ({})),
+  getApps: vi.fn(() => []),
+}));
+
+vi.mock("firebase/auth", () => ({
+  getAuth: vi.fn(() => ({ app: { name: "[DEFAULT]" }, currentUser: null })),
+  onAuthStateChanged: vi.fn(),
+}));
+
+vi.mock("firebase/firestore", () => ({
+  getFirestore: vi.fn(() => ({ type: "firestore", app: { name: "[DEFAULT]" } })),
+  doc: vi.fn((..._args) => ({ path: "users/test/config/v1", type: "document" })),
+  getDoc: vi.fn(),
+  setDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  onSnapshot: vi.fn(),
+}));
+
+describe("FirestoreService.setDocument schema validation", () => {
+  const service = new FirestoreService();
+  const path = "users/test/config/v1";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(firestore.setDoc).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes through when no schema is supplied (back-compat)", async () => {
+    await service.setDocument(path, { anything: 1, goes: "here" });
+    expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes through when the supplied schema matches the data", async () => {
+    const schema = z.object({ value: z.number() });
+    await service.setDocument(path, { value: 42 }, { schema });
+    expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws before the Firestore call when the schema rejects the data", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const schema = z.object({ value: z.string() });
+
+    await expect(
+      // Passing a number where a string is expected — the original bug class.
+      // The deliberate `as` cast bypasses TS so the runtime validator gets to
+      // see the malformed payload (which is what we're pinning here).
+      service.setDocument<{ value: string }>(path, { value: 42 } as unknown as { value: string }, {
+        schema,
+      })
+    ).rejects.toThrow(/Data validation failed for document at users\/test\/config\/v1/);
+
+    // Critical: the write must not have happened.
+    expect(firestore.setDoc).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("forwards the merge option to setDoc", async () => {
+    await service.setDocument(path, { value: 1 }, { merge: true });
+    expect(firestore.setDoc).toHaveBeenCalledWith(expect.anything(), { value: 1 }, { merge: true });
+  });
+
+  it("defaults merge to false when omitted", async () => {
+    await service.setDocument(path, { value: 1 });
+    expect(firestore.setDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      { value: 1 },
+      { merge: false }
+    );
+  });
+});

--- a/packages/web/src/services/database/FirestoreService.ts
+++ b/packages/web/src/services/database/FirestoreService.ts
@@ -18,6 +18,7 @@ import { logger } from "../../lib/logger";
 import type {
   DatabaseService,
   GetDocumentOptions,
+  SetDocumentOptions,
   SubscribeDocumentOptions,
 } from "./DatabaseService";
 
@@ -77,7 +78,19 @@ export class FirestoreService implements DatabaseService {
     return data as T;
   }
 
-  async setDocument<T>(path: string, data: T, options?: { merge?: boolean }): Promise<void> {
+  async setDocument<T>(path: string, data: T, options?: SetDocumentOptions<T>): Promise<void> {
+    // Validate before the network call. We deliberately throw rather than
+    // log-and-write because the original bug class this guard targets is
+    // *silent* bad data — a write that succeeds and only fails later on read.
+    // See the harden-user-config-goal-data-integrity task for context.
+    if (options?.schema) {
+      const result = options.schema.safeParse(data);
+      if (!result.success) {
+        logger.error("Firestore data validation failed on write:", result.error);
+        throw new Error(`Data validation failed for document at ${path}: ${result.error.message}`);
+      }
+    }
+
     const docRef = doc(db, path);
     await setDoc(docRef, data as Record<string, unknown>, {
       merge: options?.merge ?? false,

--- a/packages/web/src/services/database/MockDatabaseService.ts
+++ b/packages/web/src/services/database/MockDatabaseService.ts
@@ -5,7 +5,7 @@
  * Use setMockData() and clearMockData() to control test state.
  */
 
-import type { DatabaseService } from "./DatabaseService";
+import type { DatabaseService, SetDocumentOptions } from "./DatabaseService";
 
 export class MockDatabaseService implements DatabaseService {
   private data = new Map<string, unknown>();
@@ -16,7 +16,18 @@ export class MockDatabaseService implements DatabaseService {
     return Promise.resolve((data as T) ?? null);
   }
 
-  setDocument<T>(path: string, data: T, options?: { merge?: boolean }): Promise<void> {
+  setDocument<T>(path: string, data: T, options?: SetDocumentOptions<T>): Promise<void> {
+    // Mirror FirestoreService: validate before the (mock) write so tests
+    // exercise the same failure path as production.
+    if (options?.schema) {
+      const result = options.schema.safeParse(data);
+      if (!result.success) {
+        return Promise.reject(
+          new Error(`Data validation failed for document at ${path}: ${result.error.message}`)
+        );
+      }
+    }
+
     if (options?.merge) {
       const existing = this.data.get(path) ?? {};
       this.data.set(path, { ...existing, ...(data as object) });

--- a/packages/web/src/services/userConfigService.test.ts
+++ b/packages/web/src/services/userConfigService.test.ts
@@ -627,6 +627,71 @@ describe("UserConfigService", () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith("Error updating user config:", error);
       consoleErrorSpy.mockRestore();
     });
+
+    /**
+     * Write-side schema validation guard.
+     *
+     * The bug class from 2026-03-23 was: bad data (numeric `Goal.metric`)
+     * persisted to Firestore and only failed later on read. With the schema
+     * passed to `setDocument`, malformed data should fail at the write call.
+     * UserConfigSchema uses `.passthrough()`, so extra fields don't trip the
+     * guard — only type mismatches do.
+     */
+    it("rejects writes whose Goal.metric is the wrong type", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const mockDocSnap = { exists: () => false };
+      vi.mocked(firestore.getDoc).mockResolvedValue(mockDocSnap as any);
+
+      const malformedGoals = {
+        goals: [
+          {
+            id: "1",
+            value: 1000,
+            label: "Bad goal",
+            // The original bug: numeric instead of string. Schema must reject.
+            metric: 0 as unknown as string,
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          },
+        ],
+      };
+
+      await expect(
+        service.updateConfigSection(
+          "goals",
+          malformedGoals as unknown as GoalsForYear,
+          2025,
+          "cycling"
+        )
+      ).rejects.toThrow(/Data validation failed/);
+
+      // The setDoc call must not have happened — the write was blocked at
+      // validation time, not just logged.
+      expect(firestore.setDoc).not.toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("permits writes when the merged document validates", async () => {
+      const mockDocSnap = { exists: () => false };
+      vi.mocked(firestore.getDoc).mockResolvedValue(mockDocSnap as any);
+
+      const validGoals: GoalsForYear = {
+        goals: [
+          {
+            id: "1",
+            value: 1000,
+            label: "Good goal",
+            metric: "distance_meters",
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
+          },
+        ],
+      };
+
+      await service.updateConfigSection("goals", validGoals, 2025, "cycling");
+
+      expect(firestore.setDoc).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("deleteConfig", () => {

--- a/packages/web/src/services/userConfigService.ts
+++ b/packages/web/src/services/userConfigService.ts
@@ -500,8 +500,18 @@ export class UserConfigService {
       // Update timestamp
       config.lastUpdated = new Date().toISOString();
 
-      // Use merge to avoid overwriting other fields
-      await this.databaseService.setDocument(this.getDocPath(), config, { merge: true });
+      // Validate the merged document against UserConfigSchema before writing.
+      // The schema-on-write guard catches the bug class from 2026-03-23 — a
+      // numeric `Goal.metric` rejected on read but persisted earlier without
+      // complaint. Validation happens on the full merged doc, not the partial
+      // section, because the partial would always be incomplete by definition
+      // (e.g. a goals-only update has no `userId` or `preferences`).
+      //
+      // Use merge to avoid overwriting other fields.
+      await this.databaseService.setDocument(this.getDocPath(), config, {
+        merge: true,
+        schema: UserConfigSchema,
+      });
     } catch (error) {
       logger.error("Error updating user config:", error);
       throw createUserFriendlyError(error, "save your changes");

--- a/packages/web/src/test/fixtures/chartTestHelpers.ts
+++ b/packages/web/src/test/fixtures/chartTestHelpers.ts
@@ -95,9 +95,14 @@ export const sampleDistanceData = {
 // ============================================================================
 
 /**
- * Generate a goal object.
+ * Build a chart-shaped goal record (`GoalMeta`).
+ *
+ * Chart presenters only render the legend-relevant subset of `Goal` — id,
+ * value, and label. This helper is *not* a full `Goal` constructor; for that,
+ * use `testGoal` from `utils/goalTestFixtures`. Naming this `createGoalMeta`
+ * keeps the difference obvious.
  */
-export function createGoal(options: { id?: string; value: number; label?: string }) {
+export function createGoalMeta(options: { id?: string; value: number; label?: string }) {
   return {
     id: options.id || `goal-${Date.now()}`,
     value: options.value,
@@ -106,24 +111,24 @@ export function createGoal(options: { id?: string; value: number; label?: string
 }
 
 /**
- * Sample goal configurations.
+ * Sample goal configurations (chart-meta shape).
  */
 export const sampleGoals = {
   /** Single goal */
-  single: () => [createGoal({ id: "1", value: 3000, label: "Base Goal" })],
+  single: () => [createGoalMeta({ id: "1", value: 3000, label: "Base Goal" })],
 
   /** Two goals - typical setup */
   dual: () => [
-    createGoal({ id: "1", value: 3000, label: "Base Goal" }),
-    createGoal({ id: "2", value: 5000, label: "Stretch Goal" }),
+    createGoalMeta({ id: "1", value: 3000, label: "Base Goal" }),
+    createGoalMeta({ id: "2", value: 5000, label: "Stretch Goal" }),
   ],
 
   /** Multiple goals */
   multiple: () => [
-    createGoal({ id: "1", value: 2000, label: "Minimum" }),
-    createGoal({ id: "2", value: 3000, label: "Target" }),
-    createGoal({ id: "3", value: 4000, label: "Stretch" }),
-    createGoal({ id: "4", value: 5000, label: "Epic" }),
+    createGoalMeta({ id: "1", value: 2000, label: "Minimum" }),
+    createGoalMeta({ id: "2", value: 3000, label: "Target" }),
+    createGoalMeta({ id: "3", value: 4000, label: "Stretch" }),
+    createGoalMeta({ id: "4", value: 5000, label: "Epic" }),
   ],
 
   /** No goals */

--- a/packages/web/src/types/chartData.ts
+++ b/packages/web/src/types/chartData.ts
@@ -5,6 +5,7 @@
  * chart data for Recharts components.
  */
 import type { DistanceEntry } from "./activity";
+import type { Goal } from "../utils/goalCalculations";
 
 /**
  * Base interface for merged chart data points.
@@ -49,12 +50,14 @@ export interface CurrentChartValues {
   average?: number | undefined;
 }
 
-/** Goal metadata shared between cumulative and pacing charts */
-interface GoalMeta {
-  id: string;
-  value: number;
-  label?: string | undefined;
-}
+/**
+ * Goal metadata shared between cumulative and pacing charts.
+ *
+ * Charts only need the legend-rendering subset of `Goal` (id, value, label) —
+ * they don't care about metric / timestamps. Deriving this from `Goal` via
+ * `Pick` keeps the two shapes in lockstep instead of drifting independently.
+ */
+type GoalMeta = Pick<Goal, "id" | "value" | "label">;
 
 /**
  * Goal line data for cumulative chart rendering.

--- a/packages/web/src/utils/goalCalculations.test.ts
+++ b/packages/web/src/utils/goalCalculations.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildGoal,
   calculateDesireLine,
   calculateCurrentAverageLine,
   estimateYearEndDistance,
@@ -12,7 +13,11 @@ import {
   type GoalUnitContext,
   type Goals,
 } from "./goalCalculations";
+import { testGoals } from "./goalTestFixtures";
 import type { DistanceEntry } from "../types/activity";
+
+const FIXTURE_NOW = "2025-01-01T00:00:00.000Z";
+const defaultOpts = { metric: "distance_meters", now: FIXTURE_NOW };
 
 describe("calculateDesireLine", () => {
   it("generates straight line from 0 to target", () => {
@@ -107,23 +112,26 @@ describe("estimateYearEndDistance", () => {
 
 describe("generateDefaultGoals", () => {
   it("generates 3 goals with 100-mile granularity", () => {
-    const goals = generateDefaultGoals(2650);
+    const goals = generateDefaultGoals(2650, 100, undefined, defaultOpts);
     // 2650 rounds UP to 2700 (Math.ceil(2650 / 100) * 100)
     expect(goals).toHaveLength(3);
-    expect(goals[0]).toEqual({ id: "1", value: 2600, label: "Conservative" });
-    expect(goals[1]).toEqual({ id: "2", value: 2700, label: "Target" });
-    expect(goals[2]).toEqual({ id: "3", value: 2800, label: "Stretch" });
+    expect(goals[0]?.value).toBe(2600);
+    expect(goals[0]?.label).toBe("Conservative");
+    expect(goals[1]?.value).toBe(2700);
+    expect(goals[1]?.label).toBe("Target");
+    expect(goals[2]?.value).toBe(2800);
+    expect(goals[2]?.label).toBe("Stretch");
   });
 
   it("handles exact multiples of 100", () => {
-    const goals = generateDefaultGoals(2500);
+    const goals = generateDefaultGoals(2500, 100, undefined, defaultOpts);
     expect(goals[0]?.value).toBe(2400);
     expect(goals[1]?.value).toBe(2500);
     expect(goals[2]?.value).toBe(2600);
   });
 
   it("supports custom granularity", () => {
-    const goals = generateDefaultGoals(2650, 1000);
+    const goals = generateDefaultGoals(2650, 1000, undefined, defaultOpts);
     // Rounds up to 3000
     expect(goals[0]?.value).toBe(2000);
     expect(goals[1]?.value).toBe(3000);
@@ -131,7 +139,7 @@ describe("generateDefaultGoals", () => {
   });
 
   it("ensures all goals are unique and > 0 for small estimates", () => {
-    const goals = generateDefaultGoals(50);
+    const goals = generateDefaultGoals(50, 100, undefined, defaultOpts);
     // Rounds up to 100. Instead of 0 for conservative (which is invalid),
     // uses half-granularity (50) to ensure all goals are unique and > 0
     expect(goals[0]?.value).toBe(50);
@@ -149,41 +157,77 @@ describe("generateDefaultGoals", () => {
 
   it("uses minValue to ensure meaningful goals when no data exists", () => {
     // Simulates cycling with no data: estimatedDistance=0, granularity=100, minValue=2500
-    const cyclingGoals = generateDefaultGoals(0, 100, 2500);
+    const cyclingGoals = generateDefaultGoals(0, 100, 2500, defaultOpts);
     expect(cyclingGoals[0]?.value).toBe(2400); // Conservative
     expect(cyclingGoals[1]?.value).toBe(2500); // Target
     expect(cyclingGoals[2]?.value).toBe(2600); // Stretch
 
     // Simulates yoga with no data: estimatedDistance=0, granularity=10, minValue=100
-    const yogaGoals = generateDefaultGoals(0, 10, 100);
+    const yogaGoals = generateDefaultGoals(0, 10, 100, defaultOpts);
     expect(yogaGoals[0]?.value).toBe(90); // Conservative
     expect(yogaGoals[1]?.value).toBe(100); // Target
     expect(yogaGoals[2]?.value).toBe(110); // Stretch
 
     // Simulates running with no data: estimatedDistance=0, granularity=10, minValue=1000
-    const runningGoals = generateDefaultGoals(0, 10, 1000);
+    const runningGoals = generateDefaultGoals(0, 10, 1000, defaultOpts);
     expect(runningGoals[0]?.value).toBe(990); // Conservative
     expect(runningGoals[1]?.value).toBe(1000); // Target
     expect(runningGoals[2]?.value).toBe(1010); // Stretch
   });
 
-  it("returns Goals type with id and label", () => {
-    const goals = generateDefaultGoals(1000);
+  it("stamps every required proto field on each goal", () => {
+    // The shape returned by `generateDefaultGoals` is what the reset button in
+    // GoalControls writes to Firestore. Pin every field so no future code path
+    // can sneak a partial goal through this constructor.
+    const goals = generateDefaultGoals(1000, 100, undefined, defaultOpts);
     goals.forEach((goal) => {
-      expect(goal).toHaveProperty("id");
-      expect(goal).toHaveProperty("value");
-      expect(goal).toHaveProperty("label");
+      expect(goal.id).toEqual(expect.any(String));
+      expect(goal.value).toEqual(expect.any(Number));
+      expect(goal.label).toEqual(expect.any(String));
+      expect(goal.metric).toBe("distance_meters");
+      expect(goal.createdAt).toBe(FIXTURE_NOW);
+      expect(goal.updatedAt).toBe(FIXTURE_NOW);
     });
+  });
+
+  it("respects the provided metric for sport-specific defaults", () => {
+    const goals = generateDefaultGoals(100, 10, undefined, {
+      metric: "time_minutes",
+      now: FIXTURE_NOW,
+    });
+    goals.forEach((goal) => {
+      expect(goal.metric).toBe("time_minutes");
+    });
+  });
+});
+
+describe("buildGoal", () => {
+  it("populates createdAt and updatedAt from the supplied timestamp", () => {
+    const goal = buildGoal(
+      { id: "1", value: 100, label: "Conservative", metric: "distance_meters" },
+      FIXTURE_NOW
+    );
+    expect(goal.createdAt).toBe(FIXTURE_NOW);
+    expect(goal.updatedAt).toBe(FIXTURE_NOW);
+  });
+
+  it("defaults the timestamp to the wall clock when not provided", () => {
+    const before = Date.now();
+    const goal = buildGoal({ id: "1", value: 100, label: "x", metric: "distance_meters" });
+    const after = Date.now();
+    expect(new Date(goal.createdAt).getTime()).toBeGreaterThanOrEqual(before);
+    expect(new Date(goal.createdAt).getTime()).toBeLessThanOrEqual(after);
+    expect(goal.createdAt).toBe(goal.updatedAt);
   });
 });
 
 describe("validateGoals", () => {
   it("validates correct goals", () => {
-    const goals: Goals = [
+    const goals: Goals = testGoals([
       { id: "1", value: 1000 },
       { id: "2", value: 2000 },
       { id: "3", value: 3000 },
-    ];
+    ]);
     const result = validateGoals(goals);
     expect(result.valid).toBe(true);
     expect(result.error).toBeUndefined();
@@ -196,41 +240,41 @@ describe("validateGoals", () => {
   });
 
   it("rejects more than 5 goals", () => {
-    const goals: Goals = [
+    const goals: Goals = testGoals([
       { id: "1", value: 1000 },
       { id: "2", value: 2000 },
       { id: "3", value: 3000 },
       { id: "4", value: 4000 },
       { id: "5", value: 5000 },
       { id: "6", value: 6000 },
-    ];
+    ]);
     const result = validateGoals(goals);
     expect(result.valid).toBe(false);
     expect(result.error).toBe("Maximum 5 goals allowed");
   });
 
   it("rejects duplicate goal values", () => {
-    const goals: Goals = [
+    const goals: Goals = testGoals([
       { id: "1", value: 2000 },
       { id: "2", value: 2000 },
       { id: "3", value: 3000 },
-    ];
+    ]);
     const result = validateGoals(goals);
     expect(result.valid).toBe(false);
     expect(result.error).toBe("All goal values must be unique");
   });
 
   it("accepts 1-5 goals with unique values", () => {
-    const oneGoal: Goals = [{ id: "1", value: 1000 }];
+    const oneGoal: Goals = testGoals([{ id: "1", value: 1000 }]);
     expect(validateGoals(oneGoal).valid).toBe(true);
 
-    const fiveGoals: Goals = [
+    const fiveGoals: Goals = testGoals([
       { id: "1", value: 1000 },
       { id: "2", value: 2000 },
       { id: "3", value: 3000 },
       { id: "4", value: 4000 },
       { id: "5", value: 5000 },
-    ];
+    ]);
     expect(validateGoals(fiveGoals).valid).toBe(true);
   });
 });

--- a/packages/web/src/utils/goalCalculations.ts
+++ b/packages/web/src/utils/goalCalculations.ts
@@ -94,19 +94,60 @@ export function getTargetGoalValue(
 }
 
 /**
- * Individual goal with unique value
+ * Individual goal — aligned with proto `Goal` so a display-layer goal can
+ * round-trip to Firestore without late-stage field bolt-on.
+ *
+ * `value` is display-unit in the UI layer and storage-unit (meters / minutes
+ * / unitless) once converted by `goalToStorage`. The shape itself is
+ * identical across both layers, which is what closes the bug class from
+ * 2026-03-23 (partial goal writes leaking into Firestore).
  */
 export interface Goal {
-  id: string; // Unique identifier
-  value: number; // Display-unit value (miles/km for distance sports, raw count for session sports)
-  label?: string; // Optional user label
-  metric?: string; // e.g., "distance_meters", "time_minutes", "activities"
+  /** Unique identifier */
+  id: string;
+  /**
+   * Display-unit value in the UI layer (miles/km for distance sports, hours
+   * for time sports, raw count otherwise). Converted to canonical storage
+   * units via `goalToStorage` before persisting.
+   */
+  value: number;
+  /** User label; default "" matches the proto string default. */
+  label: string;
+  /** Sport metric key (e.g. "distance_meters", "time_minutes", "activities"). */
+  metric: string;
+  /** ISO timestamp stamped at goal creation. */
+  createdAt: string;
+  /** ISO timestamp stamped on every modification. */
+  updatedAt: string;
 }
 
 /**
  * Array of goals (1-5 goals)
  */
 export type Goals = Goal[];
+
+/**
+ * Build a fresh `Goal` with all proto fields populated.
+ *
+ * Centralises the "what's a complete goal?" answer so every caller (default
+ * generation, hand-add via UI, demo seeds) goes through the same constructor
+ * — no caller can accidentally produce a partial goal.
+ *
+ * `now` is injectable for deterministic tests; defaults to the wall clock.
+ */
+export function buildGoal(
+  fields: { id: string; value: number; label: string; metric: string },
+  now: string = new Date().toISOString()
+): Goal {
+  return {
+    id: fields.id,
+    value: fields.value,
+    label: fields.label,
+    metric: fields.metric,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
 
 /**
  * Calculate a straight "desire line" with daily goal from Jan 1 to Dec 31
@@ -197,23 +238,38 @@ export function estimateYearEndDistance(
 }
 
 /**
- * Helper: Generate default goals based on estimated year-end distance
- * Uses granularity for rounding and rounds up for motivation
- * Returns 3 default goals: Conservative, Target, Stretch
+ * Goal-generation context: sport-specific metric + injectable clock for tests.
  *
- * All goals are guaranteed to be:
- * - Greater than 0
- * - Unique (no duplicates)
+ * Both `generateDefaultGoals` and the reset button in `GoalControls` thread
+ * this through so every newly-minted goal arrives with its proto metadata
+ * already populated — no later code path needs to bolt fields on.
+ */
+export interface GoalGenerationOptions {
+  /** Sport metric key (e.g. "distance_meters", "time_minutes"). Required. */
+  metric: string;
+  /** ISO timestamp to stamp on createdAt/updatedAt. Defaults to wall clock; injectable for tests. */
+  now?: string;
+}
+
+/**
+ * Helper: Generate default goals based on estimated year-end distance.
+ *
+ * Returns 3 default goals (Conservative, Target, Stretch), all guaranteed to be
+ * greater than 0 and unique. Every goal carries full proto metadata (`metric`,
+ * `createdAt`, `updatedAt`) so the result can be written to Firestore without
+ * further enrichment.
  *
  * @param estimatedDistance - Estimated year-end distance/value
  * @param granularity - Rounding increment (default 100)
- * @param minValue - Minimum base value for goal generation (default: granularity)
- *                   Use this to ensure meaningful goals when no data exists
+ * @param minValue - Minimum base value for goal generation (default: granularity).
+ *                   Use to ensure meaningful goals when no data exists.
+ * @param options - Sport context (`metric`) + optional `now` for deterministic timestamps.
  */
 export function generateDefaultGoals(
   estimatedDistance: number,
   granularity: number = 100,
-  minValue?: number
+  minValue: number | undefined,
+  options: GoalGenerationOptions
 ): Goals {
   // Ensure we have a meaningful base value for goal generation
   // minValue prevents meaningless goals (like 0, 0, 100) when there's no data
@@ -233,22 +289,13 @@ export function generateDefaultGoals(
     conservativeValue = Math.max(1, Math.round(granularity / 2));
   }
 
+  const now = options.now ?? new Date().toISOString();
+  const metric = options.metric;
+
   return [
-    {
-      id: "1",
-      value: conservativeValue,
-      label: "Conservative",
-    },
-    {
-      id: "2",
-      value: rounded,
-      label: "Target",
-    },
-    {
-      id: "3",
-      value: rounded + granularity,
-      label: "Stretch",
-    },
+    buildGoal({ id: "1", value: conservativeValue, label: "Conservative", metric }, now),
+    buildGoal({ id: "2", value: rounded, label: "Target", metric }, now),
+    buildGoal({ id: "3", value: rounded + granularity, label: "Stretch", metric }, now),
   ];
 }
 

--- a/packages/web/src/utils/goalTestFixtures.ts
+++ b/packages/web/src/utils/goalTestFixtures.ts
@@ -1,0 +1,37 @@
+/**
+ * Test-only fixture helpers for `Goal` / `Goals`.
+ *
+ * The production `Goal` type matches the proto shape (6 required fields).
+ * Tests that only exercise display-layer logic (validation, pacing math,
+ * rendering) don't need to care about `metric`, `createdAt`, or `updatedAt`,
+ * so this helper fills them with stable defaults.
+ *
+ * Keep this file under `src/utils/` rather than `__test_helpers__/` because
+ * Vitest's bundler resolves it the same as any other module — separating
+ * directories adds no isolation but breaks tsc path-mapping.
+ */
+import { buildGoal, type Goal, type Goals } from "./goalCalculations";
+
+/** Stable fixed timestamp; tests that care about freshness should override. */
+const FIXTURE_TIMESTAMP = "2025-01-01T00:00:00.000Z";
+
+/** Build a `Goal` for tests, filling required proto fields with stable defaults. */
+export function testGoal(partial: Partial<Goal> & Pick<Goal, "id" | "value">): Goal {
+  const base = buildGoal(
+    {
+      id: partial.id,
+      value: partial.value,
+      label: partial.label ?? "",
+      metric: partial.metric ?? "distance_meters",
+    },
+    partial.createdAt ?? FIXTURE_TIMESTAMP
+  );
+  // Honor an explicit updatedAt if the test provided one; otherwise leave the
+  // matched-pair stamp from buildGoal (createdAt === updatedAt at creation).
+  return partial.updatedAt ? { ...base, updatedAt: partial.updatedAt } : base;
+}
+
+/** Build a `Goals` array for tests. */
+export function testGoals(partials: Array<Partial<Goal> & Pick<Goal, "id" | "value">>): Goals {
+  return partials.map(testGoal);
+}

--- a/packages/web/src/utils/migration.test.ts
+++ b/packages/web/src/utils/migration.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { isGoalUnitMigrated, markGoalUnitMigrated, migrateGoalUnitsIfNeeded } from "./migration";
-import { GOAL_STORAGE_VERSION, type GoalsForYear } from "../services/userConfigService";
+import {
+  GOAL_STORAGE_VERSION,
+  UserConfigSchema,
+  UserConfigService,
+  type GoalsForYear,
+  type UserConfig,
+} from "../services/userConfigService";
+import { MockDatabaseService } from "../services/database/MockDatabaseService";
+import { MockAuthService } from "../services/auth/MockAuthService";
 import { MILES_TO_METERS, hoursToMinutes } from "./units";
 
 const USER_ID = "user-abc";
@@ -110,5 +118,125 @@ describe("migrateGoalUnitsIfNeeded — detection order", () => {
     expect(result.goals.goals[0]?.value).toBe(2000); // unconverted
     expect(result.goals.goals[1]?.value).toBe(80000); // unconverted
     expect(result.goals.storageVersion).toBe(GOAL_STORAGE_VERSION);
+  });
+});
+
+/**
+ * Integration: migration output × write-side schema validation.
+ *
+ * `UserConfigService.updateConfigSection` now validates the merged document
+ * against `UserConfigSchema` before writing. `useGoalMigration` only marks a
+ * user/year/sport as migrated on a successful save — so any payload that
+ * fails validation triggers a retry loop on every page load forever.
+ *
+ * These tests pin that every branch of `migrateGoalUnitsIfNeeded` produces a
+ * payload that survives the writer. If you change the migration's output
+ * shape (new fields, dropped fields, type changes), one of these will catch
+ * a silent regression before it reaches production.
+ */
+describe("migration output survives write-side validation", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  /** Wrap a GoalsForYear in a minimally-valid UserConfig so the schema parse runs end-to-end. */
+  function wrapInConfig(goals: GoalsForYear, sport: string): UserConfig {
+    return {
+      schemaVersion: "2.1",
+      userId: USER_ID,
+      lastUpdated: "2025-01-01T00:00:00.000Z",
+      goals: { [String(YEAR)]: { sports: { [sport]: goals } } },
+      annotations: {},
+    };
+  }
+
+  it("conversion branch: converted distance goals validate", () => {
+    const goals = makeGoals([2400, 3000]);
+    const result = migrateGoalUnitsIfNeeded(goals, USER_ID, YEAR, "cycling", "distance");
+
+    const parsed = UserConfigSchema.safeParse(wrapInConfig(result.goals, "cycling"));
+    expect(parsed.success).toBe(true);
+  });
+
+  it("conversion branch: converted time goals validate", () => {
+    const goals = makeGoals([100, 150]);
+    const result = migrateGoalUnitsIfNeeded(goals, USER_ID, YEAR, "yoga", "time");
+
+    const parsed = UserConfigSchema.safeParse(wrapInConfig(result.goals, "yoga"));
+    expect(parsed.success).toBe(true);
+  });
+
+  it("heuristic branch: stamped (but unconverted) goals validate", () => {
+    const goals = makeGoals([3862425, 80000]);
+    const result = migrateGoalUnitsIfNeeded(goals, USER_ID, YEAR, "cycling", "distance");
+
+    const parsed = UserConfigSchema.safeParse(wrapInConfig(result.goals, "cycling"));
+    expect(parsed.success).toBe(true);
+  });
+
+  it("flag branch: pre-versioned canonical goals stamp + validate", () => {
+    markGoalUnitMigrated(USER_ID, YEAR, "cycling");
+    const goals = makeGoals([3862425, 4828032]);
+    const result = migrateGoalUnitsIfNeeded(goals, USER_ID, YEAR, "cycling", "distance");
+
+    const parsed = UserConfigSchema.safeParse(wrapInConfig(result.goals, "cycling"));
+    expect(parsed.success).toBe(true);
+  });
+
+  it("partial legacy data: missing proto fields still survive validation", () => {
+    // Construct a payload that came from pre-proto code: goals lacking
+    // `metric`, `createdAt`, and `updatedAt`. This shape can't exist in
+    // current TypeScript so we deliberately cast through `unknown`. The
+    // production read path fills these via Zod defaults, but if any code
+    // ever hands the migration a raw partial, the migration must still
+    // produce a validatable payload.
+    const partialGoals = {
+      goals: [
+        { id: "1", value: 2400, label: "Conservative" },
+        { id: "2", value: 3000, label: "Target" },
+      ],
+    } as unknown as GoalsForYear;
+
+    const result = migrateGoalUnitsIfNeeded(partialGoals, USER_ID, YEAR, "cycling", "distance");
+
+    // The merged config is what UserConfigService writes — validate that exact
+    // shape, not just the goals subtree.
+    const parsed = UserConfigSchema.safeParse(wrapInConfig(result.goals, "cycling"));
+    expect(parsed.success).toBe(true);
+  });
+
+  it("end-to-end: migrated goals write successfully through UserConfigService", async () => {
+    // Pipe a converted payload through the real UserConfigService → mock DB
+    // with the production schema guard active. If the migration ever produces
+    // something invalid, the write will throw and this test fails — exactly
+    // the production behaviour we're protecting against.
+    const databaseService = new MockDatabaseService();
+    const authService = new MockAuthService({
+      uid: USER_ID,
+      email: null,
+      displayName: null,
+      photoURL: null,
+    });
+    const service = new UserConfigService(USER_ID, "v1", { authService, databaseService });
+
+    const legacy = makeGoals([2400, 3000]);
+    const { goals: migrated } = migrateGoalUnitsIfNeeded(
+      legacy,
+      USER_ID,
+      YEAR,
+      "cycling",
+      "distance"
+    );
+
+    await expect(
+      service.updateConfigSection("goals", migrated, YEAR, "cycling")
+    ).resolves.toBeUndefined();
+
+    // Confirm the doc landed in the mock DB with the canonical values intact.
+    const stored = (await databaseService.getDocument(`users/${USER_ID}/config/v1`)) as UserConfig;
+    const writtenGoals = stored.goals?.[String(YEAR)]?.sports.cycling?.goals;
+    expect(writtenGoals).toBeDefined();
+    expect(writtenGoals?.[0]?.value).toBe(Math.round(2400 * MILES_TO_METERS));
+    expect(writtenGoals?.[1]?.value).toBe(Math.round(3000 * MILES_TO_METERS));
   });
 });


### PR DESCRIPTION
Two-part fix for the harden-user-config-goal-data-integrity task.

Write-side schema validation: FirestoreService.setDocument now accepts an optional Zod schema and throws synchronously before the network call when validation fails. UserConfigService passes UserConfigSchema on every write so the bug class from 2026-03-23 (numeric Goal.metric persisted silently, then rejected on read) fails at the source.

Goal type alignment (Option A): the display-layer Goal interface now matches the proto shape — metric, createdAt, and updatedAt are required. useGoalManager takes primaryMetric as a prop and uses buildGoal in handleAddGoal; handleGoalsChange in useSportPageData is now pure unit conversion with no late metadata bolt-on. generateDefaultGoals requires sport context so the Reset path produces complete goals too.