### PR TITLE
fix(stravapipe,dispatcher): preserve granular sport on type-change UPDATE

### DIFF
--- a/docs/architecture/pubsub-subscription-design.md
+++ b/docs/architecture/pubsub-subscription-design.md
@@ -30,7 +30,7 @@ Strava Webhook → Dispatcher (Cloud Run)
 - **Independent retry/SLA** — deauth events have a 48-hour compliance deadline ([Strava API Agreement Section 5.4](https://www.strava.com/legal/api)); activity events are best-effort
 - **Independent scaling** — deauth events are rare; activity events are frequent
 
-The dispatcher enriches activity CREATE events with full activity data from the Strava API before publishing. Downstream consumers receive `EnrichedEvent` messages with activity data inline and do not call the Strava API.
+The dispatcher enriches activity CREATE events — and type-change UPDATE events — with full activity data from the Strava API before publishing. (A type change is the one UPDATE that needs a re-fetch: Strava's webhook carries only the broad `type`, not the granular `sport_type` the `sport` column stores.) Title/private-only UPDATEs and DELETEs are published without a re-fetch. Downstream consumers receive `EnrichedEvent` messages with activity data inline and do not call the Strava API.
 
 ## Event Delivery Pattern
 

--- a/packages/dispatcher/adapters/http/handler.go
+++ b/packages/dispatcher/adapters/http/handler.go
@@ -483,6 +483,25 @@ func (h *Handler) routeWebhookEvent(ctx context.Context, w http.ResponseWriter, 
 // Any deauth/re-auth race may briefly land in the orphan branch while tokens
 // are being rewritten; we ack so Strava stops retrying and the next event
 // processes normally once the new tokens are written.
+// shouldFetchActivity reports whether this event needs the full Strava activity
+// fetched and attached as EnrichedEvent.RawActivity.
+//
+// CREATE always needs it. A type-change UPDATE needs it too: Strava's webhook
+// carries only the broad `type` ("Ride"), not the granular `sport_type`
+// ("MountainBikeRide") that downstream persists in the `sport` column — so we
+// re-fetch to recover it. Title/private-only updates (and deletes) do not.
+func shouldFetchActivity(webhook *generated.WebhookEvent) bool {
+	switch webhook.AspectType {
+	case generated.AspectType_ASPECT_TYPE_CREATE:
+		return true
+	case generated.AspectType_ASPECT_TYPE_UPDATE:
+		u := webhook.GetUpdates()
+		return u != nil && u.Type != nil
+	default:
+		return false
+	}
+}
+
 func (h *Handler) handleActivityEvent(ctx context.Context, w http.ResponseWriter, r *http.Request, webhook *generated.WebhookEvent, correlationID string) {
 	enriched := &generated.EnrichedEvent{Event: webhook}
 
@@ -529,14 +548,16 @@ func (h *Handler) handleActivityEvent(ctx context.Context, w http.ResponseWriter
 		return
 	}
 
-	if webhook.AspectType == generated.AspectType_ASPECT_TYPE_CREATE {
+	if shouldFetchActivity(webhook) {
 		rawActivity, fetchErr := h.stravaClient.FetchActivity(ctx, webhook.OwnerId, webhook.ObjectId)
 		switch {
 		case fetchErr == nil:
 			enriched.RawActivity = rawActivity
 		case errors.Is(fetchErr, ports.ErrActivityNotFound):
 			// Activity was deleted before we could fetch it — publish without
-			// activity data so downstream knows the deletion happened.
+			// activity data. Downstream then degrades gracefully: a CREATE
+			// records the deletion, a type-change UPDATE falls back to a bare
+			// metadata update (no sport clobber).
 			h.logger.Warn("Activity not found in Strava, publishing without activity data",
 				"correlation_id", correlationID,
 				"object_id", webhook.ObjectId)

--- a/packages/dispatcher/adapters/http/handler_test.go
+++ b/packages/dispatcher/adapters/http/handler_test.go
@@ -981,7 +981,9 @@ func TestHandler_EnrichmentBehavior_Create(t *testing.T) {
 	}
 }
 
-func TestHandler_EnrichmentBehavior_Update(t *testing.T) {
+// A title-only UPDATE carries no sport change, so the dispatcher does not
+// re-fetch — it publishes the bare event.
+func TestHandler_EnrichmentBehavior_Update_TitleOnly(t *testing.T) {
 	log := gcplog.NewNoOpLogger()
 	mockStrava := &portstest.MockStravaClient{}
 	mockPublisher := &portstest.MockPublisher{}
@@ -1013,12 +1015,153 @@ func TestHandler_EnrichmentBehavior_Update(t *testing.T) {
 
 	enriched := mockPublisher.Published[0]
 	if enriched.RawActivity != nil {
-		t.Error("expected no raw_activity for UPDATE event")
+		t.Error("expected no raw_activity for title-only UPDATE event")
 	}
 
 	// Verify Strava client was NOT called
 	if len(mockStrava.FetchedIDs) != 0 {
-		t.Errorf("expected no Strava fetch for UPDATE, got %v", mockStrava.FetchedIDs)
+		t.Errorf("expected no Strava fetch for title-only UPDATE, got %v", mockStrava.FetchedIDs)
+	}
+}
+
+// A type-change UPDATE must re-fetch the activity so the granular sport_type
+// (which Strava omits from the webhook) reaches downstream as raw_activity.
+func TestHandler_EnrichmentBehavior_Update_TypeChange(t *testing.T) {
+	log := gcplog.NewNoOpLogger()
+	rawActivity := []byte(`{"id":12345,"name":"Morning Ride","sport_type":"MountainBikeRide"}`)
+	mockStrava := &portstest.MockStravaClient{FetchResult: rawActivity}
+	mockPublisher := &portstest.MockPublisher{}
+
+	handler := NewHandler(mockPublisher, &portstest.MockPublisher{}, &portstest.MockSecretProvider{SubscriptionID: testSubscriptionID}, mockStrava, &portstest.MockTokenStore{}, portstest.NewAllowAllMockAllowlist(), log, nil)
+	router := handler.RegisterRoutes()
+
+	payload, marshalErr := json.Marshal(webhookproto.StravaWebhookJSON{
+		AspectType:     "update",
+		ObjectType:     "activity",
+		ObjectID:       testObjectID,
+		OwnerID:        testOwnerID,
+		EventTime:      testEventTime,
+		SubscriptionID: testSubscriptionID,
+		Updates:        map[string]string{"type": "Ride"},
+	})
+	if marshalErr != nil {
+		t.Fatalf("Failed to marshal payload: %v", marshalErr)
+	}
+
+	req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	enriched := mockPublisher.Published[0]
+	if enriched.RawActivity == nil {
+		t.Fatal("expected raw_activity to be set for type-change UPDATE event")
+	}
+	if !bytes.Equal(enriched.RawActivity, rawActivity) {
+		t.Errorf("raw_activity = %s, want %s", string(enriched.RawActivity), string(rawActivity))
+	}
+
+	// Verify Strava client WAS called for the changed activity.
+	if len(mockStrava.FetchedIDs) != 1 || mockStrava.FetchedIDs[0] != testObjectID {
+		t.Errorf("expected Strava fetch for activity %d, got %v", testObjectID, mockStrava.FetchedIDs)
+	}
+}
+
+// A type-change UPDATE whose activity was deleted before the fetch publishes a
+// bare event (no raw_activity); downstream then degrades to a no-clobber
+// metadata update rather than failing.
+func TestHandler_EnrichmentBehavior_Update_TypeChange_ActivityGone(t *testing.T) {
+	log := gcplog.NewNoOpLogger()
+	mockStrava := &portstest.MockStravaClient{FetchErr: ports.ErrActivityNotFound}
+	mockPublisher := &portstest.MockPublisher{}
+
+	handler := NewHandler(mockPublisher, &portstest.MockPublisher{}, &portstest.MockSecretProvider{SubscriptionID: testSubscriptionID}, mockStrava, &portstest.MockTokenStore{}, portstest.NewAllowAllMockAllowlist(), log, nil)
+	router := handler.RegisterRoutes()
+
+	payload, marshalErr := json.Marshal(webhookproto.StravaWebhookJSON{
+		AspectType:     "update",
+		ObjectType:     "activity",
+		ObjectID:       testObjectID,
+		OwnerID:        testOwnerID,
+		EventTime:      testEventTime,
+		SubscriptionID: testSubscriptionID,
+		Updates:        map[string]string{"type": "Ride"},
+	})
+	if marshalErr != nil {
+		t.Fatalf("Failed to marshal payload: %v", marshalErr)
+	}
+
+	req := httptest.NewRequest("POST", "/webhook", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(mockPublisher.Published) != 1 {
+		t.Fatalf("expected 1 published event, got %d", len(mockPublisher.Published))
+	}
+	if mockPublisher.Published[0].RawActivity != nil {
+		t.Error("expected no raw_activity when the activity was already deleted")
+	}
+	// The fetch was still attempted before falling back to a bare publish.
+	if len(mockStrava.FetchedIDs) != 1 {
+		t.Errorf("expected one Strava fetch attempt, got %v", mockStrava.FetchedIDs)
+	}
+}
+
+// TestShouldFetchActivity exhaustively covers the re-fetch gate: CREATE and
+// type-change UPDATE need the full activity; everything else does not.
+func TestShouldFetchActivity(t *testing.T) {
+	strptr := func(s string) *string { return &s }
+	cases := []struct {
+		name  string
+		event *generated.WebhookEvent
+		want  bool
+	}{
+		{
+			name:  "create always fetches",
+			event: &generated.WebhookEvent{AspectType: generated.AspectType_ASPECT_TYPE_CREATE},
+			want:  true,
+		},
+		{
+			name: "update with type change fetches",
+			event: &generated.WebhookEvent{
+				AspectType: generated.AspectType_ASPECT_TYPE_UPDATE,
+				Updates:    &generated.ActivityUpdates{Type: strptr("Ride")},
+			},
+			want: true,
+		},
+		{
+			name: "update title-only does not fetch",
+			event: &generated.WebhookEvent{
+				AspectType: generated.AspectType_ASPECT_TYPE_UPDATE,
+				Updates:    &generated.ActivityUpdates{Title: strptr("New title")},
+			},
+			want: false,
+		},
+		{
+			name:  "update with nil updates does not fetch",
+			event: &generated.WebhookEvent{AspectType: generated.AspectType_ASPECT_TYPE_UPDATE},
+			want:  false,
+		},
+		{
+			name:  "delete does not fetch",
+			event: &generated.WebhookEvent{AspectType: generated.AspectType_ASPECT_TYPE_DELETE},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldFetchActivity(tc.event); got != tc.want {
+				t.Errorf("shouldFetchActivity() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/packages/dispatcher/types/generated/webhook.pb.go
+++ b/packages/dispatcher/types/generated/webhook.pb.go
@@ -307,8 +307,10 @@ func (x *WebhookEvent) GetUpdates() *ActivityUpdates {
 }
 
 // EnrichedEvent wraps a WebhookEvent with optional activity data.
-// For CREATE events, raw_activity contains the full Strava API response (JSON bytes).
-// For UPDATE/DELETE events, raw_activity is not set.
+// raw_activity contains the full Strava API response (JSON bytes) for CREATE
+// events and for type-change UPDATE events (the dispatcher re-fetches the
+// activity so downstream can recover the granular sport_type the webhook
+// omits). It is not set for title/private-only UPDATEs or for DELETE events.
 type EnrichedEvent struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -316,8 +318,8 @@ type EnrichedEvent struct {
 
 	// The original webhook event with all metadata.
 	Event *WebhookEvent `protobuf:"bytes,1,opt,name=event,proto3" json:"event,omitempty"`
-	// Raw Strava API JSON response for the activity.
-	// Only populated for CREATE events.
+	// Raw Strava API JSON response for the activity. Populated for CREATE events
+	// and type-change UPDATE events; absent for bare UPDATEs and DELETEs.
 	RawActivity []byte `protobuf:"bytes,2,opt,name=raw_activity,json=rawActivity,proto3,oneof" json:"raw_activity,omitempty"`
 }
 

--- a/packages/stravapipe/src/stravapipe/adapters/postgres/_repository.py
+++ b/packages/stravapipe/src/stravapipe/adapters/postgres/_repository.py
@@ -15,11 +15,81 @@ from stravapipe.domain import StandardActivity
 from stravapipe.ports.out.postgres import ActivityRepository
 
 # Whitelist of allowed update keys and their corresponding SQL clauses
-# This prevents SQL injection by only allowing known, safe column updates
+# This prevents SQL injection by only allowing known, safe column updates.
+#
+# A bare `type` update writes ONLY the `type` column — never `sport`. Strava's
+# UPDATE webhook carries the broad `type` ("Ride") but not the granular
+# `sport_type` ("MountainBikeRide"); the `sport` column stores the latter
+# (domain `sport` property = `sport_type`). Writing the broad type into `sport`
+# would corrupt the granular value and break GROUP BY. `sport` is refreshed
+# only via `upsert()`, on the enriched (re-fetched) UPDATE path.
 _ALLOWED_UPDATE_CLAUSES: Final[dict[str, list[str]]] = {
     "title": ["name = :name"],
-    "type": ["type = :type", "sport = :sport"],
+    "type": ["type = :type"],
 }
+
+# Columns for a full activity write, in INSERT order. Single source of truth so
+# `insert` and `upsert` can't drift when a column is added — adding one here
+# (plus a line in `_activity_write_params`) updates both SQL statements and the
+# upsert SET clause below. `id` and `created_at` are insert-only: never in the
+# ON CONFLICT DO UPDATE SET, so the original `created_at` survives an upsert.
+_ACTIVITY_COLUMNS: Final[tuple[str, ...]] = (
+    "id",
+    "user_id",
+    "name",
+    "type",
+    "sport",
+    "start_date_local",
+    "distance",
+    "moving_time",
+    "elapsed_time",
+    "total_elevation_gain",
+    "average_speed",
+    "max_speed",
+    "average_heartrate",
+    "max_heartrate",
+    "year",
+    "created_at",
+    "updated_at",
+)
+_ACTIVITY_INSERT_ONLY_COLUMNS: Final[frozenset[str]] = frozenset({"id", "created_at"})
+
+_ACTIVITY_INSERT_SQL: Final[str] = (
+    f"INSERT INTO desirelines.activities ({', '.join(_ACTIVITY_COLUMNS)}) "
+    f"VALUES ({', '.join(f':{col}' for col in _ACTIVITY_COLUMNS)})"
+)
+_ACTIVITY_UPSERT_SET_SQL: Final[str] = ", ".join(
+    f"{col} = EXCLUDED.{col}"
+    for col in _ACTIVITY_COLUMNS
+    if col not in _ACTIVITY_INSERT_ONLY_COLUMNS
+)
+
+
+def _activity_write_params(activity: StandardActivity, now: datetime) -> dict[str, Any]:
+    """Bind params for a full activity write (``insert`` / ``upsert``).
+
+    ``created_at`` and ``updated_at`` are both set to ``now``; on an upsert
+    conflict ``created_at`` isn't in the SET clause, so the original is kept.
+    """
+    return {
+        "id": activity.id,
+        "user_id": activity.user_id,
+        "name": activity.name,
+        "type": activity.type,
+        "sport": activity.sport,
+        "start_date_local": activity.start_date_local,
+        "distance": activity.distance,
+        "moving_time": activity.moving_time,
+        "elapsed_time": activity.elapsed_time,
+        "total_elevation_gain": activity.total_elevation_gain,
+        "average_speed": activity.average_speed,
+        "max_speed": activity.max_speed,
+        "average_heartrate": activity.average_heartrate,
+        "max_heartrate": activity.max_heartrate,
+        "year": activity.year,
+        "created_at": now,
+        "updated_at": now,
+    }
 
 
 class SqlAlchemyActivityRepository(ActivityRepository):
@@ -53,46 +123,35 @@ class SqlAlchemyActivityRepository(ActivityRepository):
         Returns:
             True if inserted, False if already existed (conflict)
         """
-        query = text("""
-            INSERT INTO desirelines.activities (
-                id, user_id, name, type, sport, start_date_local,
-                distance, moving_time, elapsed_time, total_elevation_gain,
-                average_speed, max_speed, average_heartrate, max_heartrate,
-                year, created_at, updated_at
-            ) VALUES (
-                :id, :user_id, :name, :type, :sport, :start_date_local,
-                :distance, :moving_time, :elapsed_time, :total_elevation_gain,
-                :average_speed, :max_speed, :average_heartrate, :max_heartrate,
-                :year, :created_at, :updated_at
-            )
-            ON CONFLICT (id) DO NOTHING
-            RETURNING id
-        """)
-
-        now = datetime.now(UTC)
+        query = text(f"{_ACTIVITY_INSERT_SQL} ON CONFLICT (id) DO NOTHING RETURNING id")
         result = self._session.execute(
-            query,
-            {
-                "id": activity.id,
-                "user_id": activity.user_id,
-                "name": activity.name,
-                "type": activity.type,
-                "sport": activity.sport,
-                "start_date_local": activity.start_date_local,
-                "distance": activity.distance,
-                "moving_time": activity.moving_time,
-                "elapsed_time": activity.elapsed_time,
-                "total_elevation_gain": activity.total_elevation_gain,
-                "average_speed": activity.average_speed,
-                "max_speed": activity.max_speed,
-                "average_heartrate": activity.average_heartrate,
-                "max_heartrate": activity.max_heartrate,
-                "year": activity.year,
-                "created_at": now,
-                "updated_at": now,
-            },
+            query, _activity_write_params(activity, datetime.now(UTC))
         )
         # RETURNING id only returns a row if insert happened (not on conflict)
+        return result.fetchone() is not None
+
+    def upsert(self, activity: StandardActivity) -> bool:
+        """Insert activity, or refresh every column if it already exists.
+
+        Used for enriched UPDATE webhooks (a type change) where the dispatcher
+        re-fetched the full Strava activity. ON CONFLICT DO UPDATE refreshes all
+        columns from authoritative Strava data, preserving the original
+        `created_at`. Always affects one row, so always returns True.
+
+        Routes are intentionally not touched here: a type change doesn't alter
+        geometry, and the route was written on CREATE. (In the rare case the
+        row is *inserted* here — a type-change UPDATE arriving before its
+        CREATE — the route is left unpopulated; a later re-sync/backfill covers
+        that edge.)
+        """
+        query = text(
+            f"{_ACTIVITY_INSERT_SQL} "
+            f"ON CONFLICT (id) DO UPDATE SET {_ACTIVITY_UPSERT_SET_SQL} "
+            f"RETURNING id"
+        )
+        result = self._session.execute(
+            query, _activity_write_params(activity, datetime.now(UTC))
+        )
         return result.fetchone() is not None
 
     def insert_route(self, activity_id: int, geojson: str) -> bool:
@@ -167,13 +226,14 @@ class SqlAlchemyActivityRepository(ActivityRepository):
             params["name"] = updates["title"]
 
         if "type" in updates:
-            # Strava webhooks send 'type' (base type like "Ride") not 'sport_type'
-            # (specific type like "MountainBikeRide"). While lossy, updating both
-            # columns is better than leaving stale data - "Ride" is more correct
-            # than "Run" if the user changed their activity type.
+            # Update `type` only. Strava's UPDATE webhook sends the broad `type`
+            # ("Ride"), not the granular `sport_type` ("MountainBikeRide") that
+            # the `sport` column holds — so we deliberately leave `sport` intact
+            # rather than clobber it with the lossy base type. When the
+            # dispatcher re-fetches the activity on a type change, the enriched
+            # path uses `upsert()` instead and refreshes `sport` correctly.
             set_clauses.extend(_ALLOWED_UPDATE_CLAUSES["type"])
             params["type"] = updates["type"]
-            params["sport"] = updates["type"]
 
         if not set_clauses:
             return None  # No valid updates provided

--- a/packages/stravapipe/src/stravapipe/cloudrun/postgres_writer_app.py
+++ b/packages/stravapipe/src/stravapipe/cloudrun/postgres_writer_app.py
@@ -191,7 +191,7 @@ async def handle_pubsub(request: Request) -> WebhookResponse:
             event, event_data, cid, session_factory, pg_hist, tracer, freshness_hist
         ),
         on_update=lambda event, event_data, cid: _handle_update(
-            event, cid, session_factory, pg_hist, tracer, freshness_hist
+            event, event_data, cid, session_factory, pg_hist, tracer, freshness_hist
         ),
         on_delete=lambda event, event_data, cid: _handle_delete(
             event, cid, session_factory, pg_hist, tracer, freshness_hist
@@ -324,16 +324,91 @@ async def _handle_create(
     )
 
 
-async def _handle_update(
-    event: pb.WebhookEvent,
+def _handle_update_enriched(
+    activity_id: int,
+    raw_activity: Any,
     correlation_id: str,
     session_factory: sessionmaker[Session],
     pg_histogram: Histogram | None = None,
     tracer: Tracer | None = None,
     freshness_histogram: Histogram | None = None,
 ) -> WebhookResponse:
-    """Handle UPDATE events - update metadata if activity exists."""
+    """Refresh an existing activity from a re-fetched Strava payload.
+
+    Type-change UPDATEs arrive with the full ``raw_activity`` the dispatcher
+    re-fetched, so we parse it (same as CREATE) and ``upsert`` the whole row.
+    This is the only path that updates the granular ``sport`` column.
+    """
+    # ValidationError → 422 so Pub/Sub acks immediately; retrying a malformed
+    # payload will fail identically. Mirrors the CREATE path.
+    activity = validate_or_422(StandardActivity, raw_activity, context="raw_activity")
+
+    uow = SqlAlchemyUnitOfWork(session_factory, tracer=tracer)
+    with (
+        record_span(
+            tracer,
+            "postgres.upsert",
+            db_attributes(
+                "postgresql",
+                "desirelines",
+                "UPDATE",
+                {"desirelines.activity_id": activity_id},
+            ),
+        ),
+        record_duration(pg_histogram, {"operation": "upsert"}),
+        uow,
+    ):
+        uow.activities.upsert(activity)
+        uow.commit()
+
+    _record_freshness(freshness_histogram, "update")
+    logger.info(
+        "Refreshed activity %s from enriched UPDATE",
+        activity_id,
+        extra={"user_id": activity.user_id},
+    )
+    return WebhookResponse(
+        status=ResponseStatus.UPDATED,
+        activity_id=activity_id,
+        correlation_id=correlation_id,
+    )
+
+
+async def _handle_update(
+    event: pb.WebhookEvent,
+    event_data: dict[str, Any],
+    correlation_id: str,
+    session_factory: sessionmaker[Session],
+    pg_histogram: Histogram | None = None,
+    tracer: Tracer | None = None,
+    freshness_histogram: Histogram | None = None,
+) -> WebhookResponse:
+    """Handle UPDATE events.
+
+    Two legs:
+
+    - **Enriched** (``raw_activity`` present): the dispatcher re-fetched the
+      full Strava activity because the `type` changed, so we refresh the whole
+      row via ``upsert`` — the only path that updates the granular ``sport``
+      column correctly. Same parse path as CREATE.
+    - **Bare** (no ``raw_activity``): a title/private-only change, or a
+      type-change whose dispatcher fetch failed. Apply only the metadata we
+      trust (``name`` / ``type``); never clobber ``sport`` with the broad type.
+    """
     activity_id = event.object_id
+
+    raw_activity = event_data.get("raw_activity")
+    if raw_activity is not None:
+        return _handle_update_enriched(
+            activity_id,
+            raw_activity,
+            correlation_id,
+            session_factory,
+            pg_histogram,
+            tracer,
+            freshness_histogram,
+        )
+
     updates = event.updates
 
     # Extract relevant updates from typed ActivityUpdates message

--- a/packages/stravapipe/src/stravapipe/ports/out/postgres.py
+++ b/packages/stravapipe/src/stravapipe/ports/out/postgres.py
@@ -47,6 +47,24 @@ class ActivityRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def upsert(self, activity: StandardActivity) -> bool:
+        """Insert activity, or refresh every column if it already exists.
+
+        Used for enriched UPDATE webhooks (a type change), where the dispatcher
+        re-fetched the full Strava activity so we can recover the granular
+        ``sport_type`` the webhook omits. Unlike ``insert`` (ON CONFLICT DO
+        NOTHING), this refreshes all columns from authoritative Strava data,
+        preserving the original ``created_at``. Always affects exactly one row.
+
+        Args:
+            activity: StandardActivity domain model (full, freshly fetched)
+
+        Returns:
+            True (an upsert always inserts or updates exactly one row)
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def exists(self, activity_id: int) -> bool:
         """Check if activity exists in database.
 

--- a/packages/stravapipe/tests/integration/test_postgres_repository.py
+++ b/packages/stravapipe/tests/integration/test_postgres_repository.py
@@ -103,15 +103,18 @@ class TestActivityRepository:
         ).fetchone()
         assert row.name == "Evening Run"
 
-    def test_update_metadata_changes_type_and_sport(self, uow, db_session):
-        """update_metadata updates both type and sport columns.
+    def test_update_metadata_type_does_not_clobber_sport(self, uow, db_session):
+        """A bare `type` update writes `type` only and leaves `sport` intact.
 
-        Strava webhooks send 'type' (base type like "Ride") not 'sport_type'
-        (specific type like "MountainBikeRide"). While lossy, updating both
-        columns is better than leaving stale data - "Ride" is more correct
-        than "Run" if the user changed their activity type.
+        Strava's UPDATE webhook sends the broad `type` ("Ride") but not the
+        granular `sport_type` ("MountainBikeRide") that the `sport` column
+        holds. Writing the broad type into `sport` would corrupt the granular
+        value and break GROUP BY, so `update_metadata` must not touch `sport`.
+        The enriched (re-fetched) path uses `upsert` to refresh `sport`.
         """
+        # CREATE-time sport is the granular sport_type ("MountainBikeRide").
         activity = make_activity(activity_id=100005)
+        activity = activity.model_copy(update={"sport_type": "MountainBikeRide"})
 
         with uow:
             uow.activities.insert(activity)
@@ -127,8 +130,60 @@ class TestActivityRepository:
             text("SELECT type, sport FROM desirelines.activities WHERE id = :id"),
             {"id": 100005},
         ).fetchone()
+        assert row.type == "Ride"  # broad type updated
+        assert row.sport == "MountainBikeRide"  # granular sport preserved
+
+    def test_upsert_refreshes_sport_on_existing_row(self, uow, db_session):
+        """upsert refreshes every column (incl. granular `sport`), keeps created_at."""
+        # Existing row from CREATE.
+        original = make_activity(activity_id=100007, name="Old Name")
+        original = original.model_copy(update={"sport_type": "Run"})
+        with uow:
+            uow.activities.insert(original)
+            uow.commit()
+
+        created_row = db_session.execute(
+            text("SELECT created_at FROM desirelines.activities WHERE id = :id"),
+            {"id": 100007},
+        ).fetchone()
+
+        # Re-fetched activity after a type change Run -> MountainBikeRide.
+        refreshed = make_activity(activity_id=100007, name="New Name")
+        refreshed = refreshed.model_copy(
+            update={"type": "Ride", "sport_type": "MountainBikeRide"}
+        )
+        with uow:
+            result = uow.activities.upsert(refreshed)
+            uow.commit()
+
+        assert result is True
+        row = db_session.execute(
+            text(
+                "SELECT name, type, sport, created_at "
+                "FROM desirelines.activities WHERE id = :id"
+            ),
+            {"id": 100007},
+        ).fetchone()
+        assert row.name == "New Name"
         assert row.type == "Ride"
-        assert row.sport == "Ride"
+        assert row.sport == "MountainBikeRide"  # granular value refreshed
+        assert row.created_at == created_row.created_at  # preserved on conflict
+
+    def test_upsert_inserts_when_missing(self, uow, db_session):
+        """upsert inserts a row that doesn't exist yet (UPDATE before CREATE)."""
+        activity = make_activity(activity_id=100008)
+        activity = activity.model_copy(update={"sport_type": "GravelRide"})
+
+        with uow:
+            result = uow.activities.upsert(activity)
+            uow.commit()
+
+        assert result is True
+        row = db_session.execute(
+            text("SELECT sport FROM desirelines.activities WHERE id = :id"),
+            {"id": 100008},
+        ).fetchone()
+        assert row.sport == "GravelRide"
 
     def test_update_metadata_returns_false_for_missing(self, uow):
         """update_metadata returns False for non-existent activity."""

--- a/packages/stravapipe/tests/unit/cloudrun/test_postgres_writer_app.py
+++ b/packages/stravapipe/tests/unit/cloudrun/test_postgres_writer_app.py
@@ -442,6 +442,63 @@ class TestUpdateEventHandling:
             assert data["status"] == "skipped"
             assert data["reason"] == "not_found"
 
+    def test_update_event_enriched_refreshes_via_upsert(self, client):
+        """UPDATE carrying raw_activity (type change) refreshes the row via upsert."""
+        # Dispatcher re-fetched the activity, so the enriched UPDATE carries the
+        # full payload with the granular sport_type.
+        webhook = make_webhook_payload(
+            aspect_type="update", raw_activity=SAMPLE_RAW_ACTIVITY
+        )
+        webhook["updates"] = {"type": "Run"}
+
+        mock_uow = MagicMock()
+
+        with patch(
+            "stravapipe.cloudrun.postgres_writer_app.SqlAlchemyUnitOfWork",
+            return_value=mock_uow,
+        ):
+            response = client.post(
+                "/",
+                headers=make_cloudevent_headers(),
+                json=make_pubsub_body(webhook),
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "updated"
+        # Enriched path upserts the full activity; it must NOT go through the
+        # lossy bare metadata path.
+        mock_uow.activities.upsert.assert_called_once()
+        mock_uow.activities.update_metadata.assert_not_called()
+        upserted = mock_uow.activities.upsert.call_args.args[0]
+        assert upserted.sport == "Run"  # granular sport_type from raw_activity
+
+    def test_update_event_bare_type_uses_metadata_path(self, client):
+        """UPDATE without raw_activity (fetch failed / title-only) stays on the
+        bare metadata path and never upserts."""
+        webhook = make_webhook_payload(aspect_type="update")  # no raw_activity
+        webhook["updates"] = {"type": "Ride"}
+
+        mock_uow = MagicMock()
+        mock_uow.activities.exists.return_value = True
+        mock_uow.activities.update_metadata.return_value = True
+
+        with patch(
+            "stravapipe.cloudrun.postgres_writer_app.SqlAlchemyUnitOfWork",
+            return_value=mock_uow,
+        ):
+            response = client.post(
+                "/",
+                headers=make_cloudevent_headers(),
+                json=make_pubsub_body(webhook),
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "updated"
+        mock_uow.activities.upsert.assert_not_called()
+        mock_uow.activities.update_metadata.assert_called_once_with(
+            12345678, {"type": "Ride"}
+        )
+
 
 class TestDeleteEventHandling:
     """Tests for DELETE aspect_type handling."""
@@ -523,6 +580,23 @@ class TestErrorHandling:
             aspect_type="create",
             raw_activity={"clearly": "not a valid strava activity"},
         )
+        response = client.post(
+            "/",
+            headers=make_cloudevent_headers(),
+            json=make_pubsub_body(webhook),
+        )
+
+        assert response.status_code == 422
+        assert "raw_activity" in response.json()["detail"]
+
+    def test_malformed_raw_activity_on_update_returns_422(self, client):
+        """Enriched UPDATE with a malformed raw_activity also 422s (same parse path)."""
+        webhook = make_webhook_payload(
+            aspect_type="update",
+            raw_activity={"clearly": "not a valid strava activity"},
+        )
+        webhook["updates"] = {"type": "Ride"}
+
         response = client.post(
             "/",
             headers=make_cloudevent_headers(),
@@ -628,6 +702,39 @@ class TestFreshnessEmission:
         mock_histogram.record.assert_called_once()
         elapsed_ms, labels = mock_histogram.record.call_args.args
         assert 0 < elapsed_ms < 60_000
+        assert labels == {"aspect_type": "update"}
+
+    def test_enriched_update_emits_freshness_when_attribute_present(self, client):
+        """Enriched UPDATE (raw_activity) records freshness with aspect_type=update."""
+        import time
+
+        mock_histogram = self._mock_freshness_histogram()
+        mock_uow = MagicMock()
+
+        received_at_ms = int(time.time() * 1000) - 500
+
+        webhook = make_webhook_payload(
+            aspect_type="update", raw_activity=SAMPLE_RAW_ACTIVITY
+        )
+        webhook["updates"] = {"type": "Run"}
+
+        with patch(
+            "stravapipe.cloudrun.postgres_writer_app.SqlAlchemyUnitOfWork",
+            return_value=mock_uow,
+        ):
+            response = client.post(
+                "/",
+                headers=make_cloudevent_headers(),
+                json=make_pubsub_body(
+                    webhook, dispatcher_received_at_ms=received_at_ms
+                ),
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "updated"
+        mock_uow.activities.upsert.assert_called_once()
+        mock_histogram.record.assert_called_once()
+        _elapsed_ms, labels = mock_histogram.record.call_args.args
         assert labels == {"aspect_type": "update"}
 
     def test_delete_emits_freshness_when_attribute_present(self, client):

--- a/schemas/proto/desirelines/webhook/v1/webhook.proto
+++ b/schemas/proto/desirelines/webhook/v1/webhook.proto
@@ -77,14 +77,16 @@ message WebhookEvent {
 }
 
 // EnrichedEvent wraps a WebhookEvent with optional activity data.
-// For CREATE events, raw_activity contains the full Strava API response (JSON bytes).
-// For UPDATE/DELETE events, raw_activity is not set.
+// raw_activity contains the full Strava API response (JSON bytes) for CREATE
+// events and for type-change UPDATE events (the dispatcher re-fetches the
+// activity so downstream can recover the granular sport_type the webhook
+// omits). It is not set for title/private-only UPDATEs or for DELETE events.
 message EnrichedEvent {
   // The original webhook event with all metadata.
   WebhookEvent event = 1;
 
-  // Raw Strava API JSON response for the activity.
-  // Only populated for CREATE events.
+  // Raw Strava API JSON response for the activity. Populated for CREATE events
+  // and type-change UPDATE events; absent for bare UPDATEs and DELETEs.
   optional bytes raw_activity = 2;
 }
 


### PR DESCRIPTION
Strava's UPDATE webhook carries only the broad `type` ("Ride"), not the granular `sport_type` ("MountainBikeRide") that the `sport` column stores. The postgres-writer was clobbering `sport` with the base type, which shifted activities between GROUP BY aggregation buckets and lost the granular value.

The dispatcher now re-fetches the full activity on a type-change UPDATE (reusing the existing CREATE enrichment path) and ships it as `raw_activity`; the writer upserts the whole row, refreshing `sport` from authoritative data. Bare UPDATEs (title/private-only, or a failed fetch) update `type` only and never touch `sport`.

- dispatcher: shouldFetchActivity() widens the Strava fetch to type-change UPDATEs, reusing the not-found/orphan/500 handling
- proto: EnrichedEvent.raw_activity now set for CREATE + type-change UPDATE
- stravapipe: ActivityRepository.upsert() (INSERT ... ON CONFLICT DO UPDATE), shared column/params helpers; type updates no longer write sport
- tests: Go gate + activity-gone degradation; Python unit + integration (no-clobber, upsert refresh/insert), verified against real Postgres
- docs: pubsub-subscription-design enrichment note

Forward fix only; repairing already-corrupted rows is tracked separately.