### PR TITLE
refactor(web): migrate routes map to react-map-gl

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^19.2.3",
         "react-error-boundary": "^6.1.1",
         "react-loading-skeleton": "^3.5.0",
+        "react-map-gl": "^8.1.1",
         "recharts": "^3.3.0",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.1.18",
@@ -1618,6 +1619,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "minimist": "^1.2.8",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -3128,6 +3162,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vis.gl/react-mapbox": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.1.1.tgz",
+      "integrity": "sha512-KMDTjtWESXxHS4uqWxjsvgQUHvuL3Z6SdKe68o7Nxma2qUfuyH3x4TCkIqGn3FQTrFvZLWvTnSAbGvtm+Kd13A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "mapbox-gl": ">=3.5.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vis.gl/react-maplibre": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-maplibre/-/react-maplibre-8.1.1.tgz",
+      "integrity": "sha512-iUOfzJAhFAJwEZp1644tQb7LOTFgi5/GzdaztkhzNgFVuoF2Ez7guvwZjQAKB9CN2TlHTgNuYH8UW85kO7cVhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^19.2.1"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=4.0.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -3410,6 +3479,15 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -3556,6 +3634,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ast-types-flow": {
@@ -3749,6 +3836,25 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "node_modules/bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2"
       }
     },
     "node_modules/call-bind": {
@@ -4962,6 +5068,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5297,6 +5415,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/glob-parent": {
@@ -5725,6 +5852,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5834,6 +5970,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -6011,6 +6159,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -6167,6 +6324,12 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -6689,6 +6852,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mrmime": {
@@ -7217,6 +7389,30 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/react-map-gl": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-8.1.1.tgz",
+      "integrity": "sha512-aSqFAFoxvY7wxbGI93Dz0E41171mkAb3GcNbnkFIotmu88OFw495os6mIDZSi7irYNT/PZEIOEHUxhun4ToGuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vis.gl/react-mapbox": "8.1.1",
+        "@vis.gl/react-maplibre": "8.1.1"
+      },
+      "peerDependencies": {
+        "mapbox-gl": ">=1.13.0",
+        "maplibre-gl": ">=1.13.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        },
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-redux": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
@@ -7455,6 +7651,12 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
@@ -7629,6 +7831,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7750,11 +7967,83 @@
         "node": ">=18"
       }
     },
+    "node_modules/sort-asc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise": "^1.1.0",
+        "get-value": "^2.0.2",
+        "is-extendable": "^0.1.1",
+        "sort-asc": "^0.2.0",
+        "sort-desc": "^0.2.0",
+        "union-value": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8297,6 +8586,21 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "node_modules/typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -8331,6 +8635,21 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/unplugin": {
       "version": "3.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^19.2.3",
     "react-error-boundary": "^6.1.1",
     "react-loading-skeleton": "^3.5.0",
+    "react-map-gl": "^8.1.1",
     "recharts": "^3.3.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.1.18",

--- a/packages/web/src/api/map.test.ts
+++ b/packages/web/src/api/map.test.ts
@@ -96,7 +96,7 @@ describe("fetchRouteRegions", () => {
 
   it("passes through regions and the default viewport", async () => {
     const viewport = {
-      regionId: "metro-nyc",
+      regionId: 101,
       name: "New York",
       kind: "metro",
       activityCount: 42,

--- a/packages/web/src/api/map.ts
+++ b/packages/web/src/api/map.ts
@@ -7,7 +7,8 @@ import { throwApiError } from "./errors";
  * `RegionSummary` shape returned by `GET /v1/activities/map/regions`.
  */
 export interface RegionSummary {
-  regionId: string;
+  /** Numeric region id from `desirelines.regions` (apigateway serializes int64 → JSON number). */
+  regionId: number;
   name: string;
   /** Server-defined region granularity (e.g. "metro", "country"). */
   kind: string;

--- a/packages/web/src/components/routes/RouteMap.test.tsx
+++ b/packages/web/src/components/routes/RouteMap.test.tsx
@@ -3,81 +3,72 @@ import { render, act } from "@testing-library/react";
 import RouteMap from "./RouteMap";
 import type { RegionSummary } from "../../api/map";
 
-// Fake mapbox-gl Map that captures constructor options + event handlers so the
-// tests can exercise the real transformRequest / error callbacks.
+// Mock react-map-gl: capture the props RouteMap wires into <Map> (transformRequest,
+// onError, initialViewState, mapStyle) and the declarative <Source>/<Layer> props,
+// and expose a fake `fitBounds` through the forwarded MapRef so the viewport-fit
+// effect can be exercised without WebGL.
 const h = vi.hoisted(() => {
-  type Handler = (arg?: unknown) => void;
-  class FakeMap {
-    opts: Record<string, unknown>;
-    handlers: Record<string, Handler[]> = {};
-    sources: Record<string, unknown> = {};
-    layers: Record<string, unknown> = {};
-    paint: Record<string, unknown> = {};
-    fitBoundsCalls: unknown[] = [];
-    removed = false;
-    constructor(opts: Record<string, unknown>) {
-      this.opts = opts;
-      instances.push(this);
-    }
-    addControl() {
-      return this;
-    }
-    on(ev: string, cb: Handler) {
-      (this.handlers[ev] ||= []).push(cb);
-      return this;
-    }
-    emit(ev: string, arg?: unknown) {
-      (this.handlers[ev] || []).forEach((cb) => cb(arg));
-    }
-    getSource(id: string) {
-      return this.sources[id];
-    }
-    getLayer(id: string) {
-      return this.layers[id];
-    }
-    addSource(id: string, s: unknown) {
-      this.sources[id] = s;
-    }
-    addLayer(l: { id: string }) {
-      this.layers[l.id] = l;
-    }
-    removeLayer(id: string) {
-      delete this.layers[id];
-    }
-    removeSource(id: string) {
-      delete this.sources[id];
-    }
-    setPaintProperty(layer: string, prop: string, val: unknown) {
-      this.paint[`${layer}.${prop}`] = val;
-    }
-    getStyle() {
-      return {};
-    }
-    setStyle(s: unknown) {
-      this.opts.style = s;
-    }
-    fitBounds(bounds: unknown) {
-      this.fitBoundsCalls.push(bounds);
-    }
-    resize() {}
-    remove() {
-      this.removed = true;
-    }
-  }
-  class FakeNavigationControl {}
-  const instances: FakeMap[] = [];
-  return { instances, FakeMap, FakeNavigationControl };
+  const captured = {
+    transformRequest: undefined as ((url: string) => unknown) | undefined,
+    onError: undefined as ((e: unknown) => void) | undefined,
+    initialViewState: undefined as Record<string, unknown> | undefined,
+    mapStyle: undefined as string | undefined,
+    fitBoundsCalls: [] as unknown[],
+    sources: [] as Record<string, unknown>[],
+    layers: [] as Record<string, unknown>[],
+    sourceMounts: 0,
+  };
+  return { captured };
 });
 
-vi.mock("mapbox-gl", () => ({
-  default: { Map: h.FakeMap, NavigationControl: h.FakeNavigationControl, accessToken: "" },
-}));
+vi.mock("react-map-gl/mapbox", async () => {
+  const React = await import("react");
+  const Map = React.forwardRef(function Map(
+    props: Record<string, unknown> & { children?: React.ReactNode },
+    ref: React.Ref<unknown>
+  ) {
+    h.captured.transformRequest = props.transformRequest as (url: string) => unknown;
+    h.captured.onError = props.onError as (e: unknown) => void;
+    h.captured.initialViewState = props.initialViewState as Record<string, unknown>;
+    h.captured.mapStyle = props.mapStyle as string;
+    React.useImperativeHandle(ref, () => ({
+      fitBounds: (...args: unknown[]) => h.captured.fitBoundsCalls.push(args),
+    }));
+    return React.createElement("div", { "data-testid": "map" }, props.children);
+  });
+  const Source = (props: Record<string, unknown> & { children?: React.ReactNode }) => {
+    // Count mounts (not renders): a `key` change remounts the component, so this
+    // increments only on a genuine source recreation — the tile re-fetch mechanism.
+    React.useEffect(() => {
+      h.captured.sourceMounts += 1;
+    }, []);
+    h.captured.sources.push(props);
+    return React.createElement(React.Fragment, null, props.children);
+  };
+  const Layer = (props: Record<string, unknown>) => {
+    h.captured.layers.push(props);
+    return null;
+  };
+  const NavigationControl = () => null;
+  return { __esModule: true, Map, default: Map, Source, Layer, NavigationControl };
+});
 vi.mock("mapbox-gl/dist/mapbox-gl.css", () => ({}));
 
 const API_BASE = "http://localhost:8084/api/v1";
 const TILE_URL = "http://localhost:8084/api/v1/activities/map/tiles/{z}/{x}/{y}";
 const A_TILE = "http://localhost:8084/api/v1/activities/map/tiles/1/2/3";
 const MAPBOX_URL = "https://api.mapbox.com/styles/v1/mapbox/dark-v11";
+
+function resetCaptured() {
+  h.captured.transformRequest = undefined;
+  h.captured.onError = undefined;
+  h.captured.initialViewState = undefined;
+  h.captured.mapStyle = undefined;
+  h.captured.fitBoundsCalls.length = 0;
+  h.captured.sources.length = 0;
+  h.captured.layers.length = 0;
+  h.captured.sourceMounts = 0;
+}
 
 function renderMap(overrides: Partial<React.ComponentProps<typeof RouteMap>> = {}) {
   const props = {
@@ -91,22 +82,21 @@ function renderMap(overrides: Partial<React.ComponentProps<typeof RouteMap>> = {
     isDark: true,
     ...overrides,
   };
-  render(<RouteMap {...props} />);
-  const map = h.instances.at(-1)!;
-  return { map, props };
+  const utils = render(<RouteMap {...props} />);
+  return { props, ...utils };
 }
 
 type TransformRequest = (url: string) => { url: string; headers?: Record<string, string> };
 
 describe("RouteMap transformRequest auth invariant", () => {
   beforeEach(() => {
-    h.instances.length = 0;
+    resetCaptured();
     vi.clearAllMocks();
   });
 
   it("attaches the Bearer token to internal tile requests", () => {
-    const { map } = renderMap();
-    const transformRequest = map.opts.transformRequest as TransformRequest;
+    renderMap();
+    const transformRequest = h.captured.transformRequest as TransformRequest;
 
     expect(transformRequest(A_TILE)).toEqual({
       url: A_TILE,
@@ -115,15 +105,15 @@ describe("RouteMap transformRequest auth invariant", () => {
   });
 
   it("never attaches the token to Mapbox's own (external) requests", () => {
-    const { map } = renderMap();
-    const transformRequest = map.opts.transformRequest as TransformRequest;
+    renderMap();
+    const transformRequest = h.captured.transformRequest as TransformRequest;
 
     expect(transformRequest(MAPBOX_URL)).toEqual({ url: MAPBOX_URL });
   });
 
   it("attaches no header when the token is undefined", () => {
-    const { map } = renderMap({ getAuthToken: () => undefined });
-    const transformRequest = map.opts.transformRequest as TransformRequest;
+    renderMap({ getAuthToken: () => undefined });
+    const transformRequest = h.captured.transformRequest as TransformRequest;
 
     expect(transformRequest(A_TILE)).toEqual({ url: A_TILE });
   });
@@ -131,37 +121,48 @@ describe("RouteMap transformRequest auth invariant", () => {
 
 describe("RouteMap layer setup", () => {
   beforeEach(() => {
-    h.instances.length = 0;
+    resetCaptured();
     vi.clearAllMocks();
   });
 
-  it("adds the MVT source + line layer with the backend source-layer on style load", () => {
-    const { map } = renderMap();
-    act(() => map.emit("style.load"));
+  it("declares the MVT vector source + line layer with the backend source-layer", () => {
+    renderMap();
 
-    expect(map.getSource("routes-src")).toMatchObject({ type: "vector", tiles: [TILE_URL] });
-    expect(map.getLayer("routes-lines")).toMatchObject({
+    expect(h.captured.sources.at(-1)).toMatchObject({
+      id: "routes-src",
+      type: "vector",
+      tiles: [TILE_URL],
+    });
+    expect(h.captured.layers.at(-1)).toMatchObject({
+      id: "routes-lines",
       type: "line",
-      source: "routes-src",
       "source-layer": "routes",
     });
+  });
+
+  it("themes the basemap and passes the color expression to the line layer", () => {
+    renderMap({ isDark: false, colorExpression: "rgb(1,2,3)" });
+
+    expect(h.captured.mapStyle).toBe("mapbox://styles/mapbox/light-v11");
+    expect((h.captured.layers.at(-1)!.paint as Record<string, unknown>)["line-color"]).toBe(
+      "rgb(1,2,3)"
+    );
   });
 });
 
 describe("RouteMap 401 recovery", () => {
   beforeEach(() => {
-    h.instances.length = 0;
+    resetCaptured();
     vi.clearAllMocks();
   });
 
   it("refreshes the token on an internal 401 tile error (debounced)", async () => {
     const refreshAuthToken = vi.fn().mockResolvedValue(undefined);
-    const { map } = renderMap({ refreshAuthToken });
-    act(() => map.emit("style.load"));
+    renderMap({ refreshAuthToken });
 
     act(() => {
-      map.emit("error", { error: { status: 401, url: A_TILE } });
-      map.emit("error", { error: { status: 401, url: A_TILE } });
+      h.captured.onError!({ error: { status: 401, url: A_TILE } });
+      h.captured.onError!({ error: { status: 401, url: A_TILE } });
     });
     await act(async () => {
       await Promise.resolve();
@@ -170,20 +171,34 @@ describe("RouteMap 401 recovery", () => {
     expect(refreshAuthToken).toHaveBeenCalledTimes(1);
   });
 
+  it("remounts the routes source after a 401 refresh to force a tile re-fetch", async () => {
+    const refreshAuthToken = vi.fn().mockResolvedValue(undefined);
+    renderMap({ refreshAuthToken });
+    const mountsBefore = h.captured.sourceMounts;
+
+    await act(async () => {
+      h.captured.onError!({ error: { status: 401, url: A_TILE } });
+      await Promise.resolve();
+    });
+
+    // Bumped key → react-map-gl unmounts + remounts the source (removeSource/addSource).
+    expect(h.captured.sourceMounts).toBeGreaterThan(mountsBefore);
+  });
+
   it("does NOT refresh the Firebase token on a Mapbox-side (external) 401", () => {
     const refreshAuthToken = vi.fn().mockResolvedValue(undefined);
-    const { map } = renderMap({ refreshAuthToken });
+    renderMap({ refreshAuthToken });
 
-    act(() => map.emit("error", { error: { status: 401, url: MAPBOX_URL } }));
+    act(() => h.captured.onError!({ error: { status: 401, url: MAPBOX_URL } }));
 
     expect(refreshAuthToken).not.toHaveBeenCalled();
   });
 
   it("ignores non-401 errors", () => {
     const refreshAuthToken = vi.fn().mockResolvedValue(undefined);
-    const { map } = renderMap({ refreshAuthToken });
+    renderMap({ refreshAuthToken });
 
-    act(() => map.emit("error", { error: { status: 500, url: A_TILE, message: "boom" } }));
+    act(() => h.captured.onError!({ error: { status: 500, url: A_TILE, message: "boom" } }));
 
     expect(refreshAuthToken).not.toHaveBeenCalled();
   });
@@ -191,7 +206,7 @@ describe("RouteMap 401 recovery", () => {
 
 describe("RouteMap viewport fitting", () => {
   beforeEach(() => {
-    h.instances.length = 0;
+    resetCaptured();
     vi.clearAllMocks();
   });
 
@@ -205,35 +220,40 @@ describe("RouteMap viewport fitting", () => {
     isDark: true,
   };
   const regionA: RegionSummary = {
-    regionId: "A",
+    regionId: 1,
     name: "A",
     kind: "metro",
     activityCount: 1,
     bbox: [0, 0, 1, 1],
   };
-  const regionB: RegionSummary = { ...regionA, regionId: "B", bbox: [2, 2, 3, 3] };
+  const regionB: RegionSummary = { ...regionA, regionId: 2, bbox: [2, 2, 3, 3] };
 
-  it("does not re-fit the constructor-fitted region on mount", () => {
+  it("fits the initial region via initialViewState, not a re-fit on mount", () => {
     render(<RouteMap {...baseProps} defaultViewport={regionA} />);
-    const map = h.instances.at(-1)!;
-    // The constructor fit region A via `bounds`; the effect must not fit again.
-    expect(map.fitBoundsCalls.length).toBe(0);
+
+    // initialViewState carries the bounds; the imperative fitBounds must not re-fire.
+    expect(h.captured.initialViewState).toMatchObject({
+      bounds: [
+        [0, 0],
+        [1, 1],
+      ],
+    });
+    expect(h.captured.fitBoundsCalls.length).toBe(0);
   });
 
   it("fits when the viewport resolves but not again on a same-region refetch", () => {
     const { rerender } = render(<RouteMap {...baseProps} defaultViewport={null} />);
-    const map = h.instances.at(-1)!;
-    expect(map.fitBoundsCalls.length).toBe(0); // world view via constructor
+    expect(h.captured.fitBoundsCalls.length).toBe(0); // world view via initialViewState
 
     rerender(<RouteMap {...baseProps} defaultViewport={regionA} />);
-    expect(map.fitBoundsCalls.length).toBe(1); // first resolve → fit
+    expect(h.captured.fitBoundsCalls.length).toBe(1); // first resolve → fit
 
     // Background query refetch: new object, same regionId → no disruptive re-fit.
     rerender(<RouteMap {...baseProps} defaultViewport={{ ...regionA }} />);
-    expect(map.fitBoundsCalls.length).toBe(1);
+    expect(h.captured.fitBoundsCalls.length).toBe(1);
 
     // A genuine region change does fit again.
     rerender(<RouteMap {...baseProps} defaultViewport={regionB} />);
-    expect(map.fitBoundsCalls.length).toBe(2);
+    expect(h.captured.fitBoundsCalls.length).toBe(2);
   });
 });

--- a/packages/web/src/components/routes/RouteMap.tsx
+++ b/packages/web/src/components/routes/RouteMap.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from "react";
-import mapboxgl from "mapbox-gl";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Map, Source, Layer, NavigationControl } from "react-map-gl/mapbox";
+import type { MapRef, ErrorEvent } from "react-map-gl/mapbox";
 import "mapbox-gl/dist/mapbox-gl.css";
 import type { ExpressionSpecification, LngLatBoundsLike } from "mapbox-gl";
 import type { RegionSummary } from "../../api/map";
@@ -62,14 +63,18 @@ function bboxToBounds(bbox: [number, number, number, number]): LngLatBoundsLike 
 }
 
 /**
- * Mapbox GL slippy map rendering activity routes from the MVT tile endpoint.
+ * Mapbox GL slippy map (via react-map-gl) rendering activity routes from the MVT
+ * tile endpoint.
  *
- * Lazy-loaded (see `RoutesPage`) so `mapbox-gl` and its CSS stay out of the main
- * bundle and off every non-map page. Mutable inputs (auth token, color
- * expression) are read through refs so they update the live map without tearing
- * it down; the map is re-created only when the token or tile URL change. Theme
- * changes swap the basemap via `setStyle` (preserving pan/zoom) rather than
- * rebuilding the map.
+ * Lazy-loaded (see `RoutesPage`) so `mapbox-gl` / `react-map-gl` and the CSS stay
+ * out of the main bundle and off every non-map page. The map, MVT source, line
+ * layer, and theme are declarative props; only the two things that are inherently
+ * imperative remain hand-managed:
+ *   - `transformRequest` reads the auth token synchronously, so the token is held
+ *     in a ref (Mapbox can't `await` inside the request transform);
+ *   - the default-viewport fit re-runs only on a *genuine* region change (guarded
+ *     by the fitted regionId) so a background query refetch doesn't snap the map
+ *     back over the user's pan/zoom.
  */
 export default function RouteMap({
   accessToken,
@@ -81,180 +86,76 @@ export default function RouteMap({
   defaultViewport,
   isDark,
 }: RouteMapProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const mapRef = useRef<mapboxgl.Map | null>(null);
+  const mapRef = useRef<MapRef>(null);
 
-  // Mutable inputs read synchronously from inside Mapbox callbacks / the init
-  // effect. Kept in refs (synced post-render below) so the live map can read the
-  // latest values without being torn down and re-created.
+  // Auth inputs read synchronously from inside Mapbox callbacks. Kept in refs
+  // (synced each render) so `transformRequest` / `onError` stay stable — react-map-gl
+  // applies `transformRequest` once at construction, so it must close over refs,
+  // not the latest prop identity.
   const getAuthTokenRef = useRef(getAuthToken);
   const refreshAuthTokenRef = useRef(refreshAuthToken);
-  const colorRef = useRef(colorExpression);
-  const viewportRef = useRef(defaultViewport);
-  // Initial theme for map creation; live changes go through the setStyle effect.
-  const isDarkRef = useRef(isDark);
-  // Theme currently applied to the map, so the setStyle effect skips the initial
-  // render and only reacts to genuine theme changes.
-  const appliedDarkRef = useRef(isDark);
-  // regionId of the viewport we've already fitted, so background query refetches
-  // (new object, same region) don't snap the map back over the user's pan/zoom.
-  const fittedRegionIdRef = useRef<string | null>(null);
-
-  // Sync refs after each render. Declared before the init effect so that on
-  // mount the refs are fresh by the time the map is created.
   useEffect(() => {
     getAuthTokenRef.current = getAuthToken;
     refreshAuthTokenRef.current = refreshAuthToken;
-    colorRef.current = colorExpression;
-    viewportRef.current = defaultViewport;
-    isDarkRef.current = isDark;
   });
 
-  // (Re)create the map only when the token or tile URL change. Theme + viewport
-  // + color are handled by the in-place effects below.
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
+  // regionId of the viewport we've already fitted, so background query refetches
+  // (new object, same region) don't snap the map back over the user's pan/zoom.
+  // Seeded with the initial viewport's id since `initialViewState` fits it on mount.
+  const fittedRegionIdRef = useRef<number | null>(defaultViewport?.regionId ?? null);
 
-    mapboxgl.accessToken = accessToken;
+  // Bumped to force a clean tile re-fetch after a token refresh: remounting the
+  // <Source> (via key) does removeSource/addSource under the hood, which Mapbox
+  // needs because it won't retry tiles stuck in the "errored" state on its own.
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const refreshingRef = useRef(false);
 
-    const viewport = viewportRef.current;
-    const map = new mapboxgl.Map({
-      container,
-      style: isDarkRef.current ? DARK_STYLE : LIGHT_STYLE,
-      ...(viewport
-        ? {
-            bounds: bboxToBounds(viewport.bbox),
-            fitBoundsOptions: { padding: FIT_PADDING, maxZoom: MAX_FIT_ZOOM },
-          }
-        : { center: [0, 20], zoom: 1 }),
-      attributionControl: true,
-      // Attach our Firebase ID token to internal tile requests only. Mapbox's
-      // own style/sprite/glyph/telemetry requests (api.mapbox.com,
-      // events.mapbox.com) are external and must NOT receive the token —
-      // `isInternalRequest` mirrors the axios client.
-      transformRequest: (url) => {
-        if (!isInternalRequest(url, apiBaseUrl)) return { url };
-        const token = getAuthTokenRef.current();
-        return token ? { url, headers: { Authorization: `Bearer ${token}` } } : { url };
-      },
-    });
-    mapRef.current = map;
-    // The constructor already fit `viewport` (if any) — record it so the
-    // fit-on-viewport effect doesn't immediately re-fit the same region.
-    fittedRegionIdRef.current = viewport?.regionId ?? null;
-    // Record the theme the map was actually constructed with (the constructor
-    // used isDarkRef.current). Keeps appliedDarkRef in sync with the real applied
-    // style so the setStyle effect can't go stale across a map recreation.
-    appliedDarkRef.current = isDarkRef.current;
+  // Attach our Firebase ID token to internal tile requests only. Mapbox's own
+  // style/sprite/glyph/telemetry requests (api.mapbox.com, events.mapbox.com) are
+  // external and must NOT receive the token — `isInternalRequest` mirrors the
+  // axios client. Stable identity (token via ref) so it isn't churned per render.
+  const transformRequest = useCallback(
+    (url: string) => {
+      if (!isInternalRequest(url, apiBaseUrl)) return { url };
+      const token = getAuthTokenRef.current();
+      return token ? { url, headers: { Authorization: `Bearer ${token}` } } : { url };
+    },
+    [apiBaseUrl]
+  );
 
-    map.addControl(new mapboxgl.NavigationControl(), "top-right");
-
-    // Belt-and-suspenders: if the container wasn't fully laid out when the map
-    // was constructed (lazy chunk / layout shift), the canvas can size to the
-    // wrong height. Re-measure once loaded. Ongoing container resizes are handled
-    // by Mapbox's default trackResize (ResizeObserver).
-    map.on("load", () => map.resize());
-
-    // Adds the MVT source + line layer. Idempotent and re-run after every style
-    // load (initial load AND theme `setStyle`, which wipes user layers).
-    const addRoutesLayer = () => {
-      if (!map.getSource(SOURCE_ID)) {
-        map.addSource(SOURCE_ID, {
-          type: "vector",
-          tiles: [tileTemplateUrl],
-          minzoom: 0,
-          maxzoom: 14,
-        });
-      }
-      if (!map.getLayer(LAYER_ID)) {
-        map.addLayer({
-          id: LAYER_ID,
-          type: "line",
-          source: SOURCE_ID,
-          "source-layer": SOURCE_LAYER,
-          layout: { "line-join": "round", "line-cap": "round" },
-          paint: {
-            "line-color": colorRef.current,
-            "line-width": LINE_WIDTH,
-            "line-opacity": 0.85,
-          },
-        });
-      }
-    };
-    // Fires on the initial style load and after every `setStyle` (theme change).
-    map.on("style.load", addRoutesLayer);
-
-    // Force a clean re-fetch of route tiles (e.g. after a token refresh): mapbox
-    // won't retry tiles stuck in the "errored" state on its own.
-    const reloadRoutes = () => {
-      if (!map.getStyle()) return;
-      if (map.getLayer(LAYER_ID)) map.removeLayer(LAYER_ID);
-      if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
-      addRoutesLayer();
-    };
-
-    // On an *internal* unauthorized tile fetch, force a token refresh and then
-    // re-request the failed tiles. Gating on the URL avoids reacting to a
-    // Mapbox-side 401 (bad/over-restricted pk.* token), which a Firebase refresh
-    // would not fix. Debounced so a burst of tile 401s triggers one refresh.
-    let refreshing = false;
-    map.on("error", (e: mapboxgl.ErrorEvent) => {
+  // On an *internal* unauthorized tile fetch, force a token refresh and then
+  // re-request the failed tiles (via the source remount). Gating on the URL avoids
+  // reacting to a Mapbox-side 401 (bad/over-restricted pk.* token), which a
+  // Firebase refresh would not fix. Debounced so a burst of tile 401s triggers one
+  // refresh. Other errors surface at `warn` (not debug) so basemap/style/token
+  // failures stay visible in deployed builds.
+  const handleError = useCallback(
+    (e: ErrorEvent) => {
       const err = e.error as { status?: number; url?: string } | undefined;
       const isInternal401 =
         err?.status === 401 && (err.url === undefined || isInternalRequest(err.url, apiBaseUrl));
-      if (isInternal401 && !refreshing) {
-        refreshing = true;
+      if (isInternal401 && !refreshingRef.current) {
+        refreshingRef.current = true;
         void refreshAuthTokenRef
           .current()
-          .then(() => {
-            if (mapRef.current === map) reloadRoutes();
-          })
+          .then(() => setReloadNonce((n) => n + 1))
           .catch((refreshErr) => {
             logger.error("[RouteMap] auth token refresh after 401 failed:", refreshErr);
           })
           .finally(() => {
-            refreshing = false;
+            refreshingRef.current = false;
           });
         return;
       }
-      // Surface at warn (not debug) so basemap/style/token failures are visible
-      // in deployed builds — a swallowed style/token error renders a blank grey
-      // map with nothing in the console. Pass the raw error to keep its detail.
       logger.warn("[RouteMap] mapbox error:", e.error ?? "unknown");
-    });
+    },
+    [apiBaseUrl]
+  );
 
-    return () => {
-      mapRef.current = null;
-      map.remove();
-    };
-  }, [accessToken, tileTemplateUrl, apiBaseUrl]);
-
-  // Swap the basemap on an actual theme change without rebuilding the map
-  // (preserves pan/zoom). The `style.load` handler re-adds the routes source +
-  // layer. Skips the initial render — the constructor already set the style, and
-  // a redundant setStyle there reloads the style and can interrupt first paint.
-  useEffect(() => {
-    const map = mapRef.current;
-    if (!map || appliedDarkRef.current === isDark) return;
-    appliedDarkRef.current = isDark;
-    map.setStyle(isDark ? DARK_STYLE : LIGHT_STYLE);
-  }, [isDark]);
-
-  // Update line color in place when the sport registry (color expression) loads.
-  // No `isStyleLoaded()` guard: that returns false while tiles are in flight,
-  // which is exactly when `sportConfig` tends to resolve — the layer existing is
-  // sufficient for `setPaintProperty`.
-  useEffect(() => {
-    const map = mapRef.current;
-    if (!map || !map.getLayer(LAYER_ID)) return;
-    map.setPaintProperty(LAYER_ID, "line-color", colorExpression);
-  }, [colorExpression]);
-
-  // Fit the default viewport when it first resolves (or genuinely changes
-  // region). Guarded by the fitted regionId so a background query refetch — same
-  // region, new object reference — doesn't snap the map back over the user's
-  // pan/zoom.
+  // Fit the default viewport when it genuinely changes region. `initialViewState`
+  // already fit the region present at mount (recorded in fittedRegionIdRef), so a
+  // background query refetch — same regionId, new object — is skipped, preserving
+  // the user's pan/zoom.
   useEffect(() => {
     const map = mapRef.current;
     if (!map || !defaultViewport) return;
@@ -268,16 +169,50 @@ export default function RouteMap({
   }, [defaultViewport]);
 
   return (
-    // Size explicitly with w-full/h-full: Mapbox's CSS sets
-    // `.mapboxgl-map { position: relative }`, which overrides a Tailwind
-    // `absolute` class — so `inset-0` would no longer stretch the container and it
-    // collapses to height 0 (blank grey map). Mapbox doesn't set width/height, so
-    // `w-full h-full` fills the sized parent (the old RouteCanvas approach).
-    <div
-      ref={containerRef}
-      className="w-full h-full"
-      role="region"
-      aria-label="Map of activity routes"
-    />
+    // role/aria on a wrapper (react-map-gl owns the inner container div). Size with
+    // w-full/h-full: Mapbox's CSS forces `position: relative` on its container, so
+    // a Tailwind `absolute inset-0` would collapse to height 0 (blank grey map).
+    <div className="w-full h-full" role="region" aria-label="Map of activity routes">
+      <Map
+        ref={mapRef}
+        mapboxAccessToken={accessToken}
+        mapStyle={isDark ? DARK_STYLE : LIGHT_STYLE}
+        initialViewState={
+          defaultViewport
+            ? {
+                bounds: bboxToBounds(defaultViewport.bbox),
+                fitBoundsOptions: { padding: FIT_PADDING, maxZoom: MAX_FIT_ZOOM },
+              }
+            : { longitude: 0, latitude: 20, zoom: 1 }
+        }
+        transformRequest={transformRequest}
+        onError={handleError}
+        attributionControl={true}
+        style={{ width: "100%", height: "100%" }}
+      >
+        <NavigationControl position="top-right" />
+        {/* Remount on reloadNonce to force a clean tile re-fetch after a 401 refresh. */}
+        <Source
+          key={reloadNonce}
+          id={SOURCE_ID}
+          type="vector"
+          tiles={[tileTemplateUrl]}
+          minzoom={0}
+          maxzoom={14}
+        >
+          <Layer
+            id={LAYER_ID}
+            type="line"
+            source-layer={SOURCE_LAYER}
+            layout={{ "line-join": "round", "line-cap": "round" }}
+            paint={{
+              "line-color": colorExpression,
+              "line-width": LINE_WIDTH,
+              "line-opacity": 0.85,
+            }}
+          />
+        </Source>
+      </Map>
+    </div>
   );
 }

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+/**
+ * Badge — small status/label pill with `cva` variants, themed via the `@theme`
+ * shim. Used for active-filter summaries, counts, sport tags in the map UI.
+ */
+const badgeVariants = cva(
+  "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "border-border text-foreground",
+        destructive: "border-transparent bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+/**
+ * Button — shadcn-style button with `cva` variants, themed via the `@theme`
+ * shim (bg-primary / bg-secondary / bg-destructive / border-input / …). A plain
+ * native `<button>` (no Base UI primitive needed); pass `ref` directly (React 19).
+ */
+const buttonVariants = cva(
+  cn(
+    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium",
+    "transition-colors outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40",
+    "disabled:pointer-events-none disabled:opacity-50"
+  ),
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline:
+          "border border-input bg-card text-foreground hover:bg-accent hover:text-accent-foreground",
+        ghost: "text-foreground hover:bg-accent hover:text-accent-foreground",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-6",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: { variant: "default", size: "default" },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  ref?: React.Ref<HTMLButtonElement>;
+}
+
+function Button({ className, variant, size, ...props }: ButtonProps) {
+  return <button className={cn(buttonVariants({ variant, size }), className)} {...props} />;
+}
+
+export { Button, buttonVariants };

--- a/packages/web/src/components/ui/card.tsx
+++ b/packages/web/src/components/ui/card.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Card — shadcn-style container surface (header/title/description/content/footer),
+ * themed via the `@theme` shim (bg-card / text-card-foreground / border-border).
+ * Plain styled divs; used for KPI cards + insight panels in the map UI.
+ */
+function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-border bg-card text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col gap-1.5 p-4", className)} {...props} />;
+}
+
+function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("font-semibold leading-none tracking-tight", className)} {...props} />;
+}
+
+function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}
+
+function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("p-4 pt-0", className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex items-center p-4 pt-0", className)} {...props} />;
+}
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/packages/web/src/components/ui/combobox.test.tsx
+++ b/packages/web/src/components/ui/combobox.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  Combobox,
+  ComboboxChips,
+  ComboboxInput,
+  ComboboxContent,
+  ComboboxList,
+  ComboboxItem,
+} from "./combobox";
+
+function MultiSport({ onValueChange }: { onValueChange?: (v: unknown) => void }) {
+  return (
+    <Combobox multiple defaultValue={[]} onValueChange={onValueChange} items={["Ride", "Run"]}>
+      <ComboboxChips>
+        <ComboboxInput placeholder="Sports" />
+      </ComboboxChips>
+      <ComboboxContent>
+        <ComboboxList>
+          <ComboboxItem value="Ride">Ride</ComboboxItem>
+          <ComboboxItem value="Run">Run</ComboboxItem>
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+describe("Combobox (multi-select)", () => {
+  it("opens on input click and selects an option, firing onValueChange with the array", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+    render(<MultiSport onValueChange={onValueChange} />);
+
+    await user.click(screen.getByPlaceholderText("Sports"));
+
+    const ride = await screen.findByRole("option", { name: "Ride" });
+    await user.click(ride);
+
+    expect(onValueChange).toHaveBeenCalled();
+    expect(onValueChange.mock.calls.at(-1)![0]).toContain("Ride");
+  });
+});

--- a/packages/web/src/components/ui/combobox.tsx
+++ b/packages/web/src/components/ui/combobox.tsx
@@ -1,0 +1,181 @@
+import * as React from "react";
+import { Combobox as BaseCombobox } from "@base-ui/react/combobox";
+import { CheckIcon, CloseIcon } from "@/components/icons";
+import { cn } from "@/lib/utils";
+
+/**
+ * Combobox — shadcn-style wrapper over Base UI's Combobox, themed via the
+ * `@theme` shim. Single-select (search input) or **multi-select** (`multiple`,
+ * with selected items shown as chips) — the sport/region pickers in the map
+ * filters. Built-in client filtering is available via `BaseCombobox.useFilter`
+ * (re-exported as `useComboboxFilter`); pass `items` to `<Combobox>`.
+ *
+ *   <Combobox multiple items value onValueChange>
+ *     <ComboboxChips>
+ *       …chips… <ComboboxInput placeholder="Sports" />
+ *     </ComboboxChips>
+ *     <ComboboxContent>
+ *       <ComboboxEmpty>No matches</ComboboxEmpty>
+ *       <ComboboxList>{(item) => <ComboboxItem value={item}>{item}</ComboboxItem>}</ComboboxList>
+ *     </ComboboxContent>
+ *   </Combobox>
+ */
+const Combobox = BaseCombobox.Root;
+const ComboboxValue = BaseCombobox.Value;
+const ComboboxGroup = BaseCombobox.Group;
+const ComboboxClear = BaseCombobox.Clear;
+const useComboboxFilter = BaseCombobox.useFilter;
+
+type StringClass<T> = Omit<T, "className"> & { className?: string };
+
+function ComboboxInput({
+  className,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseCombobox.Input>>) {
+  return (
+    <BaseCombobox.Input
+      className={cn(
+        "min-w-24 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxChips({
+  className,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseCombobox.Chips>>) {
+  return (
+    <BaseCombobox.Chips
+      className={cn(
+        "flex min-h-9 w-full flex-wrap items-center gap-1.5 rounded-md border border-input bg-card px-2 py-1.5",
+        "focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/40",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxChip({
+  className,
+  children,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseCombobox.Chip>>) {
+  return (
+    <BaseCombobox.Chip
+      className={cn(
+        "flex items-center gap-1 rounded bg-secondary px-1.5 py-0.5 text-xs text-secondary-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <BaseCombobox.ChipRemove
+        className="rounded-sm opacity-60 outline-none hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/40"
+        aria-label="Remove"
+      >
+        <CloseIcon />
+      </BaseCombobox.ChipRemove>
+    </BaseCombobox.Chip>
+  );
+}
+
+function ComboboxContent({
+  className,
+  children,
+  sideOffset = 4,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseCombobox.Popup>> & { sideOffset?: number }) {
+  return (
+    <BaseCombobox.Portal>
+      <BaseCombobox.Positioner sideOffset={sideOffset} className="z-50 outline-none">
+        <BaseCombobox.Popup
+          className={cn(
+            "max-h-[min(var(--available-height),20rem)] w-[var(--anchor-width)] min-w-[8rem] overflow-y-auto overscroll-contain",
+            "rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg shadow-black/40",
+            "transition-[transform,opacity] data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </BaseCombobox.Popup>
+      </BaseCombobox.Positioner>
+    </BaseCombobox.Portal>
+  );
+}
+
+function ComboboxList({
+  className,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseCombobox.List>>) {
+  return <BaseCombobox.List className={cn("outline-none", className)} {...props} />;
+}
+
+function ComboboxItem({
+  className,
+  children,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseCombobox.Item>>) {
+  return (
+    <BaseCombobox.Item
+      className={cn(
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground outline-none",
+        "data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
+        "data-[selected]:text-primary data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <span className="flex w-4 shrink-0 items-center justify-center">
+        <BaseCombobox.ItemIndicator>
+          <CheckIcon />
+        </BaseCombobox.ItemIndicator>
+      </span>
+      <span className="truncate">{children}</span>
+    </BaseCombobox.Item>
+  );
+}
+
+function ComboboxEmpty({
+  className,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseCombobox.Empty>>) {
+  return (
+    <BaseCombobox.Empty
+      className={cn("px-2 py-1.5 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxGroupLabel({
+  className,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseCombobox.GroupLabel>>) {
+  return (
+    <BaseCombobox.GroupLabel
+      className={cn("px-2 py-1.5 text-xs font-medium text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Combobox,
+  ComboboxValue,
+  ComboboxInput,
+  ComboboxChips,
+  ComboboxChip,
+  ComboboxClear,
+  ComboboxContent,
+  ComboboxList,
+  ComboboxItem,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxGroupLabel,
+  useComboboxFilter,
+};

--- a/packages/web/src/components/ui/input.tsx
+++ b/packages/web/src/components/ui/input.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Input — shadcn-style text input, themed via the `@theme` shim. A plain native
+ * `<input>` (pass `ref` directly, React 19); use Base UI's Field for validation
+ * wiring where needed.
+ */
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  ref?: React.Ref<HTMLInputElement>;
+}
+
+function Input({ className, type, ...props }: InputProps) {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-sm text-foreground shadow-sm",
+        "placeholder:text-muted-foreground",
+        "transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "file:border-0 file:bg-transparent file:text-sm file:font-medium",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/packages/web/src/components/ui/popover.test.tsx
+++ b/packages/web/src/components/ui/popover.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Popover, PopoverTrigger, PopoverContent } from "./popover";
+
+describe("Popover", () => {
+  it("opens on trigger click and renders portalled content", async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover>
+        <PopoverTrigger>Open filters</PopoverTrigger>
+        <PopoverContent>
+          <p>Filter body</p>
+        </PopoverContent>
+      </Popover>
+    );
+
+    expect(screen.queryByText("Filter body")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open filters" }));
+    expect(await screen.findByText("Filter body")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/ui/popover.tsx
+++ b/packages/web/src/components/ui/popover.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { Popover as BasePopover } from "@base-ui/react/popover";
+import { cn } from "@/lib/utils";
+
+/**
+ * Popover — shadcn-style wrapper over Base UI's Popover, themed via the `@theme`
+ * shim. **Non-modal by default** (the map canvas must stay interactive behind
+ * map-overlay popovers — see the UI-foundation research). Anatomy:
+ *   <Popover>
+ *     <PopoverTrigger />
+ *     <PopoverContent>…</PopoverContent>
+ *   </Popover>
+ */
+const Popover = BasePopover.Root;
+const PopoverTrigger = BasePopover.Trigger;
+const PopoverClose = BasePopover.Close;
+const PopoverTitle = BasePopover.Title;
+const PopoverDescription = BasePopover.Description;
+
+type StringClass<T> = Omit<T, "className"> & { className?: string };
+type PositionerProps = React.ComponentProps<typeof BasePopover.Positioner>;
+
+function PopoverContent({
+  className,
+  children,
+  sideOffset = 4,
+  align = "center",
+  side,
+  ...props
+}: StringClass<React.ComponentProps<typeof BasePopover.Popup>> & {
+  sideOffset?: number;
+  align?: PositionerProps["align"];
+  side?: PositionerProps["side"];
+}) {
+  return (
+    <BasePopover.Portal>
+      <BasePopover.Positioner
+        sideOffset={sideOffset}
+        align={align}
+        side={side}
+        className="z-50 outline-none"
+      >
+        <BasePopover.Popup
+          className={cn(
+            "min-w-[8rem] rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-lg shadow-black/40 outline-none",
+            "transition-[transform,opacity] data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </BasePopover.Popup>
+      </BasePopover.Positioner>
+    </BasePopover.Portal>
+  );
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverClose, PopoverTitle, PopoverDescription };

--- a/packages/web/src/components/ui/slider.test.tsx
+++ b/packages/web/src/components/ui/slider.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Slider } from "./slider";
+
+describe("Slider", () => {
+  it("renders a single thumb for a scalar value", () => {
+    render(<Slider value={50} min={0} max={100} aria-label="Distance" />);
+    expect(screen.getAllByRole("slider")).toHaveLength(1);
+  });
+
+  it("renders two thumbs for a range value (the distance/time filters)", () => {
+    render(<Slider value={[20, 80]} min={0} max={100} />);
+    expect(screen.getAllByRole("slider")).toHaveLength(2);
+  });
+
+  it("derives thumb count from defaultValue when uncontrolled", () => {
+    render(<Slider defaultValue={[10, 40, 70]} min={0} max={100} />);
+    expect(screen.getAllByRole("slider")).toHaveLength(3);
+  });
+});

--- a/packages/web/src/components/ui/slider.tsx
+++ b/packages/web/src/components/ui/slider.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { Slider as BaseSlider } from "@base-ui/react/slider";
+import { cn } from "@/lib/utils";
+
+/**
+ * Slider — shadcn-style wrapper over Base UI's Slider, themed via the `@theme`
+ * shim. Supports single-thumb (`value={n}`) and **range** (`value={[lo, hi]}`,
+ * e.g. the distance/time-range filters); thumb count is derived from the value.
+ */
+type StringClass<T> = Omit<T, "className"> & { className?: string };
+
+function Slider({
+  className,
+  value,
+  defaultValue,
+  min = 0,
+  max = 100,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseSlider.Root>>) {
+  // Render one thumb per value (controlled or uncontrolled); fall back to a single
+  // thumb at `min` when neither is provided.
+  const thumbValues = React.useMemo<number[]>(() => {
+    const source = value ?? defaultValue;
+    if (Array.isArray(source)) return source as number[];
+    if (typeof source === "number") return [source];
+    return [min];
+  }, [value, defaultValue, min]);
+
+  return (
+    <BaseSlider.Root
+      value={value}
+      defaultValue={defaultValue}
+      min={min}
+      max={max}
+      className={cn("relative w-full touch-none select-none", className)}
+      {...props}
+    >
+      <BaseSlider.Control className="flex w-full items-center py-2">
+        <BaseSlider.Track className="relative h-1.5 w-full rounded-full bg-muted">
+          <BaseSlider.Indicator className="rounded-full bg-primary" />
+          {thumbValues.map((_, i) => (
+            <BaseSlider.Thumb
+              key={i}
+              index={i}
+              className={cn(
+                "size-4 rounded-full border border-primary bg-card shadow-sm outline-none",
+                "transition-colors focus-visible:ring-2 focus-visible:ring-ring/40",
+                "data-[dragging]:border-primary data-[disabled]:opacity-50"
+              )}
+            />
+          ))}
+        </BaseSlider.Track>
+      </BaseSlider.Control>
+    </BaseSlider.Root>
+  );
+}
+
+export { Slider };

--- a/packages/web/src/components/ui/static-primitives.test.tsx
+++ b/packages/web/src/components/ui/static-primitives.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Button } from "./button";
+import { Badge } from "./badge";
+import { Input } from "./input";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "./card";
+
+describe("Button", () => {
+  it("renders children and fires onClick", async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<Button onClick={onClick}>Reset</Button>);
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies variant + size classes via cva", () => {
+    render(
+      <Button variant="destructive" size="sm">
+        Delete
+      </Button>
+    );
+    const btn = screen.getByRole("button", { name: "Delete" });
+    expect(btn.className).toContain("bg-destructive");
+    expect(btn.className).toContain("h-8");
+  });
+
+  it("does not fire onClick when disabled", async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Button disabled onClick={onClick}>
+        Nope
+      </Button>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Nope" }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("Badge", () => {
+  it("renders with the default and outline variants", () => {
+    const { rerender } = render(<Badge>New</Badge>);
+    expect(screen.getByText("New").className).toContain("bg-primary");
+
+    rerender(<Badge variant="outline">Tag</Badge>);
+    expect(screen.getByText("Tag").className).toContain("border-border");
+  });
+});
+
+describe("Input", () => {
+  it("accepts typed text", async () => {
+    const user = userEvent.setup();
+    render(<Input placeholder="Search" />);
+    const input = screen.getByPlaceholderText("Search");
+
+    await user.type(input, "alps");
+    expect(input).toHaveValue("alps");
+  });
+
+  it("is non-interactive when disabled", async () => {
+    const user = userEvent.setup();
+    render(<Input placeholder="Search" disabled />);
+    const input = screen.getByPlaceholderText("Search");
+
+    await user.type(input, "x");
+    expect(input).toHaveValue("");
+    expect(input).toBeDisabled();
+  });
+});
+
+describe("Card", () => {
+  it("composes header/title/description/content/footer", () => {
+    render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Totals</CardTitle>
+          <CardDescription>This year</CardDescription>
+        </CardHeader>
+        <CardContent>1,234 km</CardContent>
+        <CardFooter>footer</CardFooter>
+      </Card>
+    );
+
+    expect(screen.getByText("Totals")).toBeInTheDocument();
+    expect(screen.getByText("This year")).toBeInTheDocument();
+    expect(screen.getByText("1,234 km")).toBeInTheDocument();
+    expect(screen.getByText("footer")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/ui/toggle-group.test.tsx
+++ b/packages/web/src/components/ui/toggle-group.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ToggleGroup, ToggleGroupItem } from "./toggle-group";
+
+function YearGroup({ onValueChange }: { onValueChange?: (v: unknown) => void }) {
+  return (
+    <ToggleGroup defaultValue={["2026"]} onValueChange={onValueChange} aria-label="Year">
+      <ToggleGroupItem value="2025">2025</ToggleGroupItem>
+      <ToggleGroupItem value="2026">2026</ToggleGroupItem>
+    </ToggleGroup>
+  );
+}
+
+describe("ToggleGroup", () => {
+  it("reflects the pressed item via aria-pressed", () => {
+    render(<YearGroup />);
+    expect(screen.getByRole("button", { name: "2026" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "2025" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("fires onValueChange when a different item is pressed", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+    render(<YearGroup onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("button", { name: "2025" }));
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange.mock.calls[0]![0]).toContain("2025");
+  });
+});

--- a/packages/web/src/components/ui/toggle-group.tsx
+++ b/packages/web/src/components/ui/toggle-group.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { ToggleGroup as BaseToggleGroup } from "@base-ui/react/toggle-group";
+import { Toggle as BaseToggle } from "@base-ui/react/toggle";
+import { cn } from "@/lib/utils";
+
+/**
+ * ToggleGroup — shadcn-style wrapper over Base UI's ToggleGroup + Toggle, themed
+ * via the `@theme` shim. Single- or multi-select (pass an array `value`); used
+ * for the year quick-select and sport toggles in the map filters.
+ *   <ToggleGroup value onValueChange>
+ *     <ToggleGroupItem value="2026">2026</ToggleGroupItem>
+ *   </ToggleGroup>
+ */
+type StringClass<T> = Omit<T, "className"> & { className?: string };
+
+function ToggleGroup({
+  className,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseToggleGroup>>) {
+  return (
+    <BaseToggleGroup
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md border border-border bg-card p-1",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseToggle>>) {
+  return (
+    <BaseToggle
+      className={cn(
+        "inline-flex items-center justify-center gap-1.5 rounded-sm px-2.5 py-1 text-sm font-medium text-foreground outline-none transition-colors",
+        "hover:bg-accent hover:text-accent-foreground",
+        "focus-visible:ring-2 focus-visible:ring-ring/40",
+        "data-[pressed]:bg-primary data-[pressed]:text-primary-foreground",
+        "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/packages/web/src/components/ui/tooltip.test.tsx
+++ b/packages/web/src/components/ui/tooltip.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "./tooltip";
+
+describe("Tooltip", () => {
+  it("shows content on trigger focus (within a provider)", async () => {
+    const user = userEvent.setup();
+    render(
+      <TooltipProvider delay={0}>
+        <Tooltip>
+          <TooltipTrigger>Info</TooltipTrigger>
+          <TooltipContent>Zoom to fit</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+
+    expect(screen.queryByText("Zoom to fit")).not.toBeInTheDocument();
+
+    await user.tab(); // focus the trigger
+    expect(screen.getByRole("button", { name: "Info" })).toHaveFocus();
+    expect(await screen.findByText("Zoom to fit")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/ui/tooltip.tsx
+++ b/packages/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { Tooltip as BaseTooltip } from "@base-ui/react/tooltip";
+import { cn } from "@/lib/utils";
+
+/**
+ * Tooltip — shadcn-style wrapper over Base UI's Tooltip, themed via the `@theme`
+ * shim. Wrap the app (or a subtree) in `<TooltipProvider>` once; then:
+ *   <Tooltip>
+ *     <TooltipTrigger />
+ *     <TooltipContent>…</TooltipContent>
+ *   </Tooltip>
+ */
+const TooltipProvider = BaseTooltip.Provider;
+const Tooltip = BaseTooltip.Root;
+const TooltipTrigger = BaseTooltip.Trigger;
+
+type StringClass<T> = Omit<T, "className"> & { className?: string };
+
+function TooltipContent({
+  className,
+  children,
+  sideOffset = 6,
+  ...props
+}: StringClass<React.ComponentProps<typeof BaseTooltip.Popup>> & { sideOffset?: number }) {
+  return (
+    <BaseTooltip.Portal>
+      <BaseTooltip.Positioner sideOffset={sideOffset} className="z-50 outline-none">
+        <BaseTooltip.Popup
+          className={cn(
+            "rounded-md border border-border bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-md shadow-black/40",
+            "transition-[transform,opacity] data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </BaseTooltip.Popup>
+      </BaseTooltip.Positioner>
+    </BaseTooltip.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/packages/web/src/hooks/useRouteRegions.test.tsx
+++ b/packages/web/src/hooks/useRouteRegions.test.tsx
@@ -23,7 +23,7 @@ import { fetchRouteRegions } from "../api/map";
 const mockFetch = vi.mocked(fetchRouteRegions);
 
 const viewport = {
-  regionId: "metro-nyc",
+  regionId: 101,
   name: "New York",
   kind: "metro",
   activityCount: 42,

--- a/packages/web/src/pages/RoutesPage.test.tsx
+++ b/packages/web/src/pages/RoutesPage.test.tsx
@@ -69,7 +69,7 @@ const authedUser = {
 };
 
 const viewport: RegionSummary = {
-  regionId: "metro-nyc",
+  regionId: 101,
   name: "New York",
   kind: "metro",
   activityCount: 42,


### PR DESCRIPTION
declarative react-map-gl (v8, react-map-gl/mapbox): \<Map\>/\<Source\>/\<Layer\>, mapStyle theming, initialViewState fitting. Removes the init useEffect, manual resize, the style.load re-add handler, the setPaintProperty/setStyle effects, and the constructor bounds glue — each a bug source during the base-map build.

- transformRequest (token via ref) attaches Bearer to internal tiles only; onError keeps the internal-401 -> refresh path, now forcing a clean tile re-fetch by re-keying <Source> instead of a manual remove/re-add.
- Viewport fit via initialViewState + a fittedRegionId-guarded fitBounds so a background regions refetch doesn't snap over the user's pan/zoom.
- Fix RegionSummary.regionId string -> number (apigateway serializes the int64 id as a JSON number); update fixtures.
- Rewrite RouteMap.test.tsx against a react-map-gl mock, preserving the transformRequest / layer / 401 / viewport coverage.