### PR TITLE
fix(shared): clean up OTel providers on partial Setup failure and bou…

### DIFF
--- a/packages/dispatcher/cmd/dispatcher/main.go
+++ b/packages/dispatcher/cmd/dispatcher/main.go
@@ -72,7 +72,12 @@ func run(log *slog.Logger) error {
 		providers = otel.NoopProviders()
 	} else {
 		defer func() {
-			if shutdownErr := otelShutdown(context.Background()); shutdownErr != nil {
+			// Bound the flush so a stuck span/metric exporter cannot hang
+			// process exit indefinitely. Reuse the same budget as the HTTP
+			// server shutdown below.
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+			defer cancel()
+			if shutdownErr := otelShutdown(shutdownCtx); shutdownErr != nil {
 				log.Error("OTel shutdown error", "error", shutdownErr)
 			}
 		}()

--- a/packages/shared/otel/provider.go
+++ b/packages/shared/otel/provider.go
@@ -175,14 +175,19 @@ func setup(
 	var shutdownFuncs []func(context.Context) error
 	shutdown := func(ctx context.Context) error {
 		var err error
-		for _, fn := range shutdownFuncs {
-			err = errors.Join(err, fn(ctx))
+		// Tear down in reverse order of construction (LIFO) so any implicit
+		// dependency between providers is unwound in the right order.
+		for i := len(shutdownFuncs) - 1; i >= 0; i-- {
+			err = errors.Join(err, shutdownFuncs[i](ctx))
 		}
 		shutdownFuncs = nil
 		return err
 	}
-	handleErr := func(cause error) error {
-		return errors.Join(cause, shutdown(ctx))
+	// Use a fresh context for the failure-path cleanup: if setup failed because
+	// the startup ctx was canceled/timed out, reusing it could skip
+	// flushing/teardown of the already-constructed providers.
+	handleErr := func(cause error) error { //nolint:contextcheck // cleanup deliberately runs on a fresh context, not the (possibly canceled) startup ctx
+		return errors.Join(cause, shutdown(context.Background()))
 	}
 
 	res, err := resource.New(ctx,

--- a/packages/shared/otel/provider.go
+++ b/packages/shared/otel/provider.go
@@ -152,6 +152,39 @@ type ShutdownFunc func(ctx context.Context) error
 // On error, callers should log a warning and use NoopProviders() — services must not
 // crash due to OTel initialization failures.
 func Setup(ctx context.Context, logger *slog.Logger, serviceName string) (*Providers, ShutdownFunc, error) {
+	return setup(ctx, logger, serviceName, newMetricReader, newTraceExporter)
+}
+
+// setup is the testable core of Setup. The metricReaderFn and traceExporterFn
+// parameters let tests substitute credential-free fakes (e.g. a ManualReader)
+// and a failing trace-exporter constructor, so the partial-failure cleanup
+// path can be exercised without GCP credentials.
+func setup(
+	ctx context.Context,
+	logger *slog.Logger,
+	serviceName string,
+	metricReaderFn func() (sdkmetric.Reader, error),
+	traceExporterFn func(context.Context) (sdktrace.SpanExporter, error),
+) (*Providers, ShutdownFunc, error) {
+	// shutdownFuncs accumulates each provider's shutdown function as it is
+	// constructed. If a later construction step fails, handleErr runs all
+	// accumulated funcs so an already-initialized provider (and its background
+	// reader goroutine / export connection) does not leak. On success they are
+	// composed into the returned ShutdownFunc. This is the canonical OTel SDK
+	// setup shape (see go.opentelemetry.io/otel docs' setupOTelSDK example).
+	var shutdownFuncs []func(context.Context) error
+	shutdown := func(ctx context.Context) error {
+		var err error
+		for _, fn := range shutdownFuncs {
+			err = errors.Join(err, fn(ctx))
+		}
+		shutdownFuncs = nil
+		return err
+	}
+	handleErr := func(cause error) error {
+		return errors.Join(cause, shutdown(ctx))
+	}
+
 	res, err := resource.New(ctx,
 		resource.WithDetectors(gcp.NewDetector()),
 		resource.WithAttributes(semconv.ServiceName(serviceName)),
@@ -161,18 +194,20 @@ func Setup(ctx context.Context, logger *slog.Logger, serviceName string) (*Provi
 	}
 
 	// --- Metrics ---
-	metricExp, err := mexporter.New()
+	reader, err := metricReaderFn()
 	if err != nil {
-		return nil, nil, fmt.Errorf("create GCP metric exporter: %w", err)
+		return nil, nil, fmt.Errorf("create metric reader: %w", err)
 	}
 
-	reader := sdkmetric.NewPeriodicReader(metricExp, sdkmetric.WithInterval(exportInterval))
 	mp := newMeterProvider(res, reader)
+	shutdownFuncs = append(shutdownFuncs, mp.Shutdown)
 
 	// --- Tracing ---
-	traceExp, err := newTraceExporter(ctx)
+	traceExp, err := traceExporterFn(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("create trace exporter: %w", err)
+		// Tear down the already-constructed MeterProvider (and its periodic
+		// reader) before returning, so it does not leak on partial failure.
+		return nil, nil, handleErr(fmt.Errorf("create trace exporter: %w", err))
 	}
 
 	// Sampler: AlwaysSample is intentional. Request volume across dispatcher
@@ -190,6 +225,8 @@ func Setup(ctx context.Context, logger *slog.Logger, serviceName string) (*Provi
 		sdktrace.WithResource(res),
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 	)
+
+	shutdownFuncs = append(shutdownFuncs, tp.Shutdown)
 
 	// Register globally so otelhttp and propagation.Inject/Extract work.
 	otelglobal.SetTracerProvider(tp)
@@ -213,14 +250,22 @@ func Setup(ctx context.Context, logger *slog.Logger, serviceName string) (*Provi
 		"trace_sampler", "AlwaysSample",
 	)
 
-	shutdown := func(ctx context.Context) error {
-		return errors.Join(tp.Shutdown(ctx), mp.Shutdown(ctx))
-	}
-
 	return &Providers{
 		Meter:  mp.Meter(scopeName),
 		Tracer: tp.Tracer(scopeName),
 	}, shutdown, nil
+}
+
+// newMetricReader builds the production metric Reader: a PeriodicReader
+// wrapping the GCP Cloud Monitoring exporter, exporting on exportInterval.
+// Extracted from Setup so the reader can be substituted with a ManualReader
+// in provider_test.go (the GCP exporter needs credentials at construction).
+func newMetricReader() (sdkmetric.Reader, error) {
+	metricExp, err := mexporter.New()
+	if err != nil {
+		return nil, fmt.Errorf("create GCP metric exporter: %w", err)
+	}
+	return sdkmetric.NewPeriodicReader(metricExp, sdkmetric.WithInterval(exportInterval)), nil
 }
 
 // newTraceExporter returns an OTLP trace exporter when one of the standard

--- a/packages/shared/otel/provider_test.go
+++ b/packages/shared/otel/provider_test.go
@@ -2,6 +2,10 @@ package otel
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
 	"testing"
 
 	otelmetric "go.opentelemetry.io/otel/metric"
@@ -9,6 +13,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -285,4 +290,109 @@ func TestNoopProviders_ReturnsUsableNoopInstruments(t *testing.T) {
 	// A no-op span must start and end without panicking.
 	_, span := p.Tracer.Start(context.Background(), "test.span")
 	span.End()
+}
+
+// shutdownTrackingReader wraps a real ManualReader and records whether
+// Shutdown was invoked. It lets TestSetup_ShutsDownMeterProviderOnTraceExporterError
+// assert that the already-constructed MeterProvider is torn down when a later
+// Setup step fails, without needing GCP credentials.
+type shutdownTrackingReader struct {
+	sdkmetric.Reader
+	mu       sync.Mutex
+	shutdown bool
+}
+
+func (r *shutdownTrackingReader) Shutdown(ctx context.Context) error {
+	r.mu.Lock()
+	r.shutdown = true
+	r.mu.Unlock()
+	if err := r.Reader.Shutdown(ctx); err != nil {
+		return fmt.Errorf("manual reader shutdown: %w", err)
+	}
+	return nil
+}
+
+func (r *shutdownTrackingReader) wasShutdown() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.shutdown
+}
+
+// noopSpanExporter is a minimal SpanExporter used to drive setup()'s happy
+// path in tests without a real (credential-requiring) trace exporter.
+type noopSpanExporter struct{}
+
+func (noopSpanExporter) ExportSpans(context.Context, []sdktrace.ReadOnlySpan) error { return nil }
+func (noopSpanExporter) Shutdown(context.Context) error                             { return nil }
+
+// TestSetup_ShutsDownMeterProviderOnTraceExporterError pins the partial-failure
+// cleanup contract: when the trace-exporter constructor fails AFTER the
+// MeterProvider has been built, setup must shut that MeterProvider (and its
+// reader) down before returning, rather than leaking its background reader
+// goroutine and export connection. It also asserts the returned error joins
+// the original cause so callers still see why Setup failed.
+func TestSetup_ShutsDownMeterProviderOnTraceExporterError(t *testing.T) {
+	reader := &shutdownTrackingReader{Reader: sdkmetric.NewManualReader()}
+
+	wantErr := errors.New("trace exporter boom")
+	failingTraceExporter := func(context.Context) (sdktrace.SpanExporter, error) {
+		return nil, wantErr
+	}
+
+	logger := slog.New(slog.DiscardHandler)
+	providers, shutdown, err := setup(
+		context.Background(),
+		logger,
+		"test-service",
+		func() (sdkmetric.Reader, error) { return reader, nil },
+		failingTraceExporter,
+	)
+
+	if err == nil {
+		t.Fatal("expected setup to return an error when the trace exporter fails")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("returned error %v does not wrap the trace-exporter cause %v", err, wantErr)
+	}
+	if providers != nil {
+		t.Errorf("expected nil Providers on failure, got %#v", providers)
+	}
+	if shutdown != nil {
+		t.Errorf("expected nil ShutdownFunc on failure, got non-nil")
+	}
+	if !reader.wasShutdown() {
+		t.Error("MeterProvider's reader was not shut down on partial Setup failure (leak)")
+	}
+}
+
+// TestSetup_ShutdownTearsDownBothProvidersOnSuccess pins the happy-path
+// contract: on a successful setup, the returned ShutdownFunc must shut down
+// BOTH the MeterProvider and the TracerProvider. A regression that dropped one
+// provider from the accumulated shutdown list would leak it on process exit.
+func TestSetup_ShutdownTearsDownBothProvidersOnSuccess(t *testing.T) {
+	reader := &shutdownTrackingReader{Reader: sdkmetric.NewManualReader()}
+
+	traceExp := &noopSpanExporter{}
+	logger := slog.New(slog.DiscardHandler)
+
+	providers, shutdown, err := setup(
+		context.Background(),
+		logger,
+		"test-service",
+		func() (sdkmetric.Reader, error) { return reader, nil },
+		func(context.Context) (sdktrace.SpanExporter, error) { return traceExp, nil },
+	)
+	if err != nil {
+		t.Fatalf("setup returned error on happy path: %v", err)
+	}
+	if providers == nil || shutdown == nil {
+		t.Fatal("expected non-nil Providers and ShutdownFunc on success")
+	}
+
+	if shutdownErr := shutdown(context.Background()); shutdownErr != nil {
+		t.Errorf("shutdown returned error: %v", shutdownErr)
+	}
+	if !reader.wasShutdown() {
+		t.Error("ShutdownFunc did not shut down the MeterProvider's reader")
+	}
 }


### PR DESCRIPTION
…nd shutdown flush

Setup constructed the MeterProvider (and its periodic reader) before the trace exporter. If the trace exporter failed, Setup returned the error without shutting the MeterProvider down, leaking its background reader goroutine and export connection.

Adopt the canonical OTel SDK pattern: accumulate each provider's shutdown func as it is constructed and, on a later failure, run all accumulated funcs (joining their errors with the cause) before returning. The same slice composes the returned ShutdownFunc on success, so happy-path behavior is unchanged.

Also bound the dispatcher's shutdown flush with a WithTimeout context (reusing the HTTP shutdown budget) instead of context.Background(), so a stuck exporter can no longer hang process exit. The apigateway already did this.

Split the metric-reader and trace-exporter construction into injectable helpers so the partial-failure cleanup path is unit-tested without GCP credentials.