### PR TITLE
fix(web): fail loudly on out-of-range int64 and drop dateless map activities

### DIFF
--- a/packages/web/src/api/map.test.ts
+++ b/packages/web/src/api/map.test.ts
@@ -262,6 +262,26 @@ describe("fetchMapDataset", () => {
     await expect(fetchMapDataset()).rejects.toThrow("throwApiError:fetchMapDataset");
   });
 
+  it("rejects a non-integer JSON-number id (the apigateway may send numbers, not just strings)", async () => {
+    // The number branch must enforce the same clean-int64 contract as the string
+    // branch — a fractional id (1.5) is drift, not a valid activity id.
+    mockGet.mockResolvedValue({
+      data: { activities: [{ activityId: 1.5, startDateLocal: "2026-05-01T08:00:00" }] },
+    });
+
+    await expect(fetchMapDataset()).rejects.toThrow("throwApiError:fetchMapDataset");
+  });
+
+  it("rejects an out-of-2^53 JSON-number id rather than accepting a rounded value", async () => {
+    // 2**53 (9007199254740992) is finite but not a safe integer — beyond this,
+    // JSON numbers can no longer represent every int64, so it must fail loudly.
+    mockGet.mockResolvedValue({
+      data: { activities: [{ activityId: 2 ** 53, startDateLocal: "2026-05-01T08:00:00" }] },
+    });
+
+    await expect(fetchMapDataset()).rejects.toThrow("throwApiError:fetchMapDataset");
+  });
+
   it("rejects a malformed regionId rather than silently dropping a NaN", async () => {
     mockGet.mockResolvedValue({
       data: {

--- a/packages/web/src/api/map.test.ts
+++ b/packages/web/src/api/map.test.ts
@@ -249,6 +249,19 @@ describe("fetchMapDataset", () => {
     await expect(fetchMapDataset()).rejects.toThrow("throwApiError:fetchMapDataset");
   });
 
+  it("rejects an out-of-2^53 int64 string rather than silently rounding it", async () => {
+    // "9007199254740993" (2^53 + 1) passes the digit regex but `Number(...)` rounds
+    // it to 9007199254740992, an id that would never match the tile — so the safe-
+    // integer guard must fail loudly instead of coercing to a rounded value.
+    mockGet.mockResolvedValue({
+      data: {
+        activities: [{ activityId: "9007199254740993", startDateLocal: "2026-05-01T08:00:00" }],
+      },
+    });
+
+    await expect(fetchMapDataset()).rejects.toThrow("throwApiError:fetchMapDataset");
+  });
+
   it("rejects a malformed regionId rather than silently dropping a NaN", async () => {
     mockGet.mockResolvedValue({
       data: {

--- a/packages/web/src/api/map.ts
+++ b/packages/web/src/api/map.ts
@@ -12,15 +12,13 @@ import type { MapActivity as WireMapActivity } from "../types/generated/activiti
  * rather than coerce to garbage.
  */
 const int64ToNumber = z.union([z.number(), z.string()]).transform((v, ctx) => {
-  if (typeof v === "number") {
-    if (Number.isFinite(v)) return v;
-  } else if (/^-?\d+$/.test(v.trim())) {
-    // Reject values beyond 2^53−1: they pass the regex but `Number(v)` silently
-    // rounds them, so an out-of-range int64 must fail loudly like other drift
-    // rather than coerce to an id that never matches the tile.
-    const n = Number(v);
-    if (Number.isSafeInteger(n)) return n;
-  }
+  // Single safe-integer guard for BOTH wire forms: a JSON number is taken as-is, a
+  // numeric string is parsed only after the digit shape-check. `Number.isSafeInteger`
+  // then rejects everything that isn't a clean int64 within ±(2^53−1) — a non-integer
+  // number (e.g. 1.5), an out-of-range value that would silently round to an id the
+  // tile never matches, or a NaN from a malformed/empty string — so drift fails loudly.
+  const n = typeof v === "number" ? v : /^-?\d+$/.test(v.trim()) ? Number(v) : NaN;
+  if (Number.isSafeInteger(n)) return n;
   ctx.addIssue({
     code: "custom",
     message: `expected an int64 (numeric string or number), got ${JSON.stringify(v)}`,

--- a/packages/web/src/api/map.ts
+++ b/packages/web/src/api/map.ts
@@ -15,7 +15,11 @@ const int64ToNumber = z.union([z.number(), z.string()]).transform((v, ctx) => {
   if (typeof v === "number") {
     if (Number.isFinite(v)) return v;
   } else if (/^-?\d+$/.test(v.trim())) {
-    return Number(v);
+    // Reject values beyond 2^53−1: they pass the regex but `Number(v)` silently
+    // rounds them, so an out-of-range int64 must fail loudly like other drift
+    // rather than coerce to an id that never matches the tile.
+    const n = Number(v);
+    if (Number.isSafeInteger(n)) return n;
   }
   ctx.addIssue({
     code: "custom",

--- a/packages/web/src/utils/mapInsights.test.ts
+++ b/packages/web/src/utils/mapInsights.test.ts
@@ -88,6 +88,25 @@ describe("mapInsights", () => {
     ]);
   });
 
+  it("drops dateless activities instead of bucketing them into a phantom 1969 point", () => {
+    // A defaulted "" start_date_local would fall back to the epoch: a 1969-12-29
+    // week bar in weeklyVolume and a ""-keyed point that sorts first in
+    // cumulativeDistance. Both aggregations must skip the row entirely.
+    const data = [
+      act({ activityId: 1, startDateLocal: "", distanceMeters: 9_000 }),
+      act({ activityId: 2, startDateLocal: "2026-05-04T08:00:00", distanceMeters: 10_000 }),
+    ];
+
+    const weeks = weeklyVolume(data);
+    expect(weeks.map((w) => w.weekStart)).toEqual(["2026-05-04"]); // no 1969 bar
+    expect(weeks[0]!.distanceMeters).toBe(10_000); // dateless 9k excluded
+    expect(weeks[0]!.count).toBe(1);
+
+    expect(cumulativeDistance(data)).toEqual([
+      { date: "2026-05-04", cumulativeMeters: 10_000 }, // no leading "" point
+    ]);
+  });
+
   it("bins distances into nice-width buckets", () => {
     const data = [
       act({ activityId: 1, distanceMeters: 1_000 }),

--- a/packages/web/src/utils/mapInsights.ts
+++ b/packages/web/src/utils/mapInsights.ts
@@ -88,6 +88,10 @@ export interface WeeklyVolumeRow {
 export function weeklyVolume(activities: MapActivity[]): WeeklyVolumeRow[] {
   const byWeek = new Map<string, WeeklyVolumeRow>();
   for (const a of activities) {
+    // Skip rows with a missing / short start date (protojson omits an empty
+    // start_date_local, defaulted to "") — otherwise ymdToDay("") falls back to
+    // the epoch and buckets the activity into a phantom 1969 week.
+    if (a.startDateLocal.length < 10) continue;
     const ws = weekStartYmd(a.startDateLocal);
     const row = byWeek.get(ws) ?? {
       weekStart: ws,
@@ -175,6 +179,9 @@ export interface CumulativePoint {
 export function cumulativeDistance(activities: MapActivity[]): CumulativePoint[] {
   const byDay = new Map<string, number>();
   for (const a of activities) {
+    // Skip dateless rows (defaulted "" start_date_local) — else `.slice(0, 10)`
+    // yields a "" key that sorts first as a phantom leading cumulative point.
+    if (a.startDateLocal.length < 10) continue;
     const d = a.startDateLocal.slice(0, 10);
     byDay.set(d, (byDay.get(d) ?? 0) + (a.distanceMeters ?? 0));
   }


### PR DESCRIPTION
int64ToNumber accepted any digit string via the /^-?\d+$/ shape check and returned Number(v), so a value above Number.MAX_SAFE_INTEGER (2^53-1) passed and was silently rounded to an id that never matches the MVT tile — contrary to the 'fail loudly on drift' contract. Add a Number.isSafeInteger guard so an out-of-range int64 is rejected through the same addIssue path as other drift.

weeklyVolume and cumulativeDistance fed a defaulted "" startDateLocal into the date helpers, bucketing dateless activities into a phantom 1969-12-29 week bar and a ""-keyed cumulative point that sorts first. Skip rows whose startDateLocal is empty / under 10 chars, mirroring the existing malformed-row guard in distanceHistogram.