### PR TITLE
fix(stravapipe): make retry_on_failure actually retry 429/5xx and stop list_activities leaking HTTPError

### DIFF
--- a/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
+++ b/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
@@ -113,10 +113,13 @@ def create_strava_breaker(
     or a 429 quota exceeded. If a transient failure on the token
     endpoint (a 503 from Strava's OAuth side, a connection reset)
     were ever wrapped as ``StravaTokenError``, the breaker would
-    silently miss the outage. The current call sites in
-    ``StravaTokenRepo._do_refresh`` honor this: 401 → ``StravaTokenError``,
-    everything else → ``StravaApiError`` (or the original ``requests``
-    exception), both of which count as breaker failures.
+    silently miss the outage. Both call sites honor this:
+    ``StravaTokenRepo._do_refresh`` maps 401 → ``StravaTokenError`` and
+    everything else (5xx, network) → ``StravaApiError``; the activity path's
+    ``_handle_error_response`` maps 404 → ``ActivityNotFoundError``, 401 →
+    ``StravaTokenError``, 429 → ``StravaRateLimitError`` (all excluded), and
+    5xx / network → ``StravaApiError`` (counted). So only permanent per-user
+    signals ever carry an excluded type.
     """
     return pybreaker.CircuitBreaker(
         fail_max=fail_max,
@@ -208,7 +211,7 @@ class StravaTokenRepo(ReadStravaToken):
 
         try:
             resp = _refresh()
-        except requests.exceptions.HTTPError as exc:
+        except requests.exceptions.RequestException as exc:
             status_code = exc.response.status_code if exc.response is not None else None
             if status_code == HTTP_UNAUTHORIZED:
                 raise StravaTokenError(
@@ -381,7 +384,7 @@ class StravaApiClient:
 
         try:
             resp = _fetch()
-        except requests.exceptions.HTTPError as exc:
+        except requests.exceptions.RequestException as exc:
             return self._handle_error_response(
                 exc,
                 activity_id=activity_id,
@@ -465,7 +468,7 @@ class StravaApiClient:
 
         try:
             resp = _fetch()
-        except requests.exceptions.HTTPError as exc:
+        except requests.exceptions.RequestException as exc:
             # Route list failures through the SAME domain-exception translation
             # as get_activity (M1) — a bare raise_for_status() here leaked
             # requests.HTTPError across the adapter boundary. activity_id=None
@@ -488,19 +491,23 @@ class StravaApiClient:
 
     def _handle_error_response[T](
         self,
-        exc: requests.exceptions.HTTPError,
+        exc: requests.exceptions.RequestException,
         *,
         token_refresh_count: int,
         retry_func: Callable[[int], T],
         activity_id: int | None = None,
     ) -> T:
-        """Translate a caught ``HTTPError`` into a domain exception.
+        """Translate a caught ``RequestException`` into a domain exception.
 
         Because each ``_fetch`` now calls ``raise_for_status()`` inside the
         retried scope, a 4xx/5xx no longer returns a ``Response`` to inspect —
-        it raises. This handler keys off the caught exception's status code
-        instead of ``resp.ok``. Shared by ``get_activity`` and
-        ``list_activities``; ``activity_id`` is ``None`` on the list path.
+        it raises. This handler keys off the caught exception's status code,
+        which is ``None`` when the request never received an HTTP response (a
+        ``ConnectionError``/``Timeout`` that survived retries). Catching the
+        ``RequestException`` base — not just ``HTTPError`` — ensures no raw
+        ``requests`` exception leaks across the adapter boundary. Shared by
+        ``get_activity`` and ``list_activities``; ``activity_id`` is ``None``
+        on the list path.
 
         Mapping (preserved exactly):
         - 401 → refresh token and retry once via ``retry_func``; a second 401
@@ -508,11 +515,14 @@ class StravaApiClient:
         - 404 → ``ActivityNotFoundError`` (single-activity path only; a 404
           has no meaning for the list endpoint, so it falls through to
           ``StravaApiError`` when ``activity_id is None``).
-        - anything else (5xx that survived retry, other 4xx) → ``StravaApiError``.
+        - anything else — a 5xx that survived retry, another 4xx, or a network
+          error with no response (status ``None``) → ``StravaApiError``, which
+          counts as a breaker failure.
 
         A 429 never reaches here: the retry decorator surfaces it as
-        ``StravaRateLimitError`` (not an ``HTTPError``), so it propagates past
-        this handler and keeps the circuit-breaker ``exclude`` contract intact.
+        ``StravaRateLimitError`` (not a ``RequestException``), so it propagates
+        past this handler and keeps the circuit-breaker ``exclude`` contract
+        intact.
         """
         status_code = exc.response.status_code if exc.response is not None else None
 

--- a/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
+++ b/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
@@ -194,20 +194,28 @@ class StravaTokenRepo(ReadStravaToken):
                 "refresh_token": self._tokens.refresh_token,
                 "grant_type": "refresh_token",
             }
-            return requests.post(
+            resp = requests.post(
                 url=self._api_config.token_url,
                 data=payload,
                 timeout=self._api_config.request_timeout,
             )
+            # Raise INSIDE the retried scope so @retry_on_failure sees 5xx/429
+            # and can retry them (a bare returned Response never triggers a
+            # retry). 401 is re-raised immediately by the decorator; 429
+            # exhaustion surfaces as StravaRateLimitError.
+            resp.raise_for_status()
+            return resp
 
-        resp = _refresh()
-
-        if not resp.ok:
-            if resp.status_code == HTTP_UNAUTHORIZED:
+        try:
+            resp = _refresh()
+        except requests.exceptions.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code == HTTP_UNAUTHORIZED:
                 raise StravaTokenError(
-                    "Token refresh failed - check credentials", resp.status_code
-                )
-            raise StravaApiError(f"Token refresh failed: {resp.text}", resp.status_code)
+                    "Token refresh failed - check credentials", status_code
+                ) from exc
+            body = exc.response.text if exc.response is not None else str(exc)
+            raise StravaApiError(f"Token refresh failed: {body}", status_code) from exc
 
         access_token = resp.json()["access_token"]
         logger.info(
@@ -360,17 +368,22 @@ class StravaApiClient:
         )
         def _fetch() -> requests.Response:
             endpoint = f"{self._api_config.api_base_url}/activities/{activity_id}"
-            return requests.get(
+            resp = requests.get(
                 url=endpoint,
                 headers=self._get_headers(),
                 timeout=self._api_config.request_timeout,
             )
+            # Raise INSIDE the retried scope so @retry_on_failure sees 5xx/429.
+            # 4xx (404/401) is re-raised immediately; 5xx is retried then
+            # re-raised; 429 exhaustion surfaces as StravaRateLimitError.
+            resp.raise_for_status()
+            return resp
 
-        resp = _fetch()
-
-        if not resp.ok:
+        try:
+            resp = _fetch()
+        except requests.exceptions.HTTPError as exc:
             return self._handle_error_response(
-                resp,
+                exc,
                 activity_id=activity_id,
                 token_refresh_count=_token_refresh_count,
                 retry_func=lambda count: self._get_activity_with_retry(
@@ -435,7 +448,7 @@ class StravaApiClient:
         )
         def _fetch() -> requests.Response:
             endpoint = f"{self._api_config.api_base_url}/athlete/activities"
-            return requests.get(
+            resp = requests.get(
                 url=endpoint,
                 headers=self._get_headers(),
                 params={
@@ -446,63 +459,74 @@ class StravaApiClient:
                 },
                 timeout=self._api_config.request_timeout,
             )
+            # Raise INSIDE the retried scope so @retry_on_failure sees 5xx/429.
+            resp.raise_for_status()
+            return resp
 
-        resp = _fetch()
-
-        if not resp.ok:
-            # Handle 401 with retry
-            if (
-                resp.status_code == HTTP_UNAUTHORIZED
-                and _token_refresh_count < self._MAX_TOKEN_REFRESH_RETRIES
-            ):
-                logger.warning(
-                    "Got 401 listing activities, refreshing token and retrying "
-                    "(attempt %d/%d)...",
-                    _token_refresh_count + 1,
-                    self._MAX_TOKEN_REFRESH_RETRIES,
-                    extra={
-                        "operation": "list_activities",
-                        "page": page,
-                        "action": "token_refresh_retry",
-                        "token_refresh_attempt": _token_refresh_count + 1,
-                        "max_token_refresh_retries": self._MAX_TOKEN_REFRESH_RETRIES,
-                    },
-                )
-                self._token_manager.refresh()
-                return self._list_activities_with_retry(
+        try:
+            resp = _fetch()
+        except requests.exceptions.HTTPError as exc:
+            # Route list failures through the SAME domain-exception translation
+            # as get_activity (M1) — a bare raise_for_status() here leaked
+            # requests.HTTPError across the adapter boundary. activity_id=None
+            # since the list endpoint isn't tied to a single activity.
+            return self._handle_error_response(
+                exc,
+                activity_id=None,
+                token_refresh_count=_token_refresh_count,
+                retry_func=lambda count: self._list_activities_with_retry(
                     before=before,
                     after=after,
                     page=page,
                     per_page=per_page,
-                    _token_refresh_count=_token_refresh_count + 1,
-                )
-            resp.raise_for_status()
+                    _token_refresh_count=count,
+                ),
+            )
 
         data: list[dict[str, Any]] = resp.json()
         return data
 
-    def _handle_error_response(
+    def _handle_error_response[T](
         self,
-        resp: requests.Response,
+        exc: requests.exceptions.HTTPError,
         *,
-        activity_id: int,
         token_refresh_count: int,
-        retry_func: Callable[[int], dict[str, Any]],
-    ) -> dict[str, Any]:
-        """Handle error responses with 401 retry and exception translation."""
-        # Handle 401: refresh token and retry
+        retry_func: Callable[[int], T],
+        activity_id: int | None = None,
+    ) -> T:
+        """Translate a caught ``HTTPError`` into a domain exception.
+
+        Because each ``_fetch`` now calls ``raise_for_status()`` inside the
+        retried scope, a 4xx/5xx no longer returns a ``Response`` to inspect —
+        it raises. This handler keys off the caught exception's status code
+        instead of ``resp.ok``. Shared by ``get_activity`` and
+        ``list_activities``; ``activity_id`` is ``None`` on the list path.
+
+        Mapping (preserved exactly):
+        - 401 → refresh token and retry once via ``retry_func``; a second 401
+          (``token_refresh_count`` exhausted) → ``StravaTokenError``.
+        - 404 → ``ActivityNotFoundError`` (single-activity path only; a 404
+          has no meaning for the list endpoint, so it falls through to
+          ``StravaApiError`` when ``activity_id is None``).
+        - anything else (5xx that survived retry, other 4xx) → ``StravaApiError``.
+
+        A 429 never reaches here: the retry decorator surfaces it as
+        ``StravaRateLimitError`` (not an ``HTTPError``), so it propagates past
+        this handler and keeps the circuit-breaker ``exclude`` contract intact.
+        """
+        status_code = exc.response.status_code if exc.response is not None else None
+
+        # Handle 401: refresh token and retry (once).
         if (
-            resp.status_code == HTTP_UNAUTHORIZED
+            status_code == HTTP_UNAUTHORIZED
             and token_refresh_count < self._MAX_TOKEN_REFRESH_RETRIES
         ):
             logger.warning(
-                "Got 401 for activity %s, refreshing token and retrying "
-                "(attempt %d/%d)...",
-                activity_id,
+                "Got 401 from Strava, refreshing token and retrying (attempt %d/%d)...",
                 token_refresh_count + 1,
                 self._MAX_TOKEN_REFRESH_RETRIES,
                 extra={
-                    "operation": "fetch_activity",
+                    "operation": "strava_api_call",
                     "activity_id": activity_id,
                     "action": "token_refresh_retry",
                     "token_refresh_attempt": token_refresh_count + 1,
@@ -512,32 +536,33 @@ class StravaApiClient:
             self._token_manager.refresh()
             return retry_func(token_refresh_count + 1)
 
-        # Log and raise appropriate exception
+        # Log and raise appropriate exception.
         logger.error(
-            "Failed to fetch activity %s: %s",
+            "Strava API call failed (status=%s, activity_id=%s)",
+            status_code,
             activity_id,
-            resp.status_code,
             extra={
-                "operation": "fetch_activity",
+                "operation": "strava_api_call",
                 "activity_id": activity_id,
-                "status_code": resp.status_code,
+                "status_code": status_code,
                 "error_type": "api_error",
             },
         )
 
-        if resp.status_code == HTTP_NOT_FOUND:
-            raise ActivityNotFoundError(activity_id)
-        if resp.status_code == HTTP_UNAUTHORIZED:
+        if status_code == HTTP_NOT_FOUND and activity_id is not None:
+            raise ActivityNotFoundError(activity_id) from exc
+        if status_code == HTTP_UNAUTHORIZED:
             raise StravaTokenError(
                 f"Access token expired after {token_refresh_count} refresh attempts",
-                resp.status_code,
+                status_code,
                 activity_id,
-            )
+            ) from exc
+        body = exc.response.text if exc.response is not None else str(exc)
         raise StravaApiError(
-            f"Failed to fetch activity {activity_id}: {resp.text}",
-            resp.status_code,
+            f"Strava API call failed ({status_code}): {body}",
+            status_code,
             activity_id,
-        )
+        ) from exc
 
 
 # =============================================================================

--- a/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
+++ b/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
@@ -6,7 +6,7 @@ This module provides a layered architecture for Strava API access:
            ↓
     StravaTokenManager   - Manages token state + thread-safety
            ↓
-    StravaApiClient      - HTTP calls, 401 retry, error translation
+    StravaApiClient      - HTTP calls, retry (5xx/429/network) + 401 refresh, error translation
            ↓
     StravaActivitiesRepo - Domain model conversion
 
@@ -363,7 +363,12 @@ class StravaApiClient:
     def _get_activity_with_retry(
         self, activity_id: int, *, _token_refresh_count: int
     ) -> dict[str, Any]:
-        """Internal: fetch activity with 401 retry logic."""
+        """Internal: fetch one activity.
+
+        Retries 5xx/429/network via ``@retry_on_failure`` (429 honoring
+        ``Retry-After``), refreshes the token once on 401, and translates any
+        surviving error to a domain exception via ``_handle_error_response``.
+        """
 
         @retry_on_failure(
             max_attempts=self._api_config.activity_retry_attempts,
@@ -443,7 +448,12 @@ class StravaApiClient:
         per_page: int,
         _token_refresh_count: int,
     ) -> list[dict[str, Any]]:
-        """Internal: list activities with 401 retry logic."""
+        """Internal: list one page of activities.
+
+        Retries 5xx/429/network via ``@retry_on_failure`` (429 honoring
+        ``Retry-After``), refreshes the token once on 401, and translates any
+        surviving error to a domain exception via ``_handle_error_response``.
+        """
 
         @retry_on_failure(
             max_attempts=self._api_config.activity_retry_attempts,

--- a/packages/stravapipe/src/stravapipe/retry.py
+++ b/packages/stravapipe/src/stravapipe/retry.py
@@ -26,6 +26,11 @@ HTTP_INTERNAL_SERVER_ERROR = 500
 # Fallback wait (seconds) when ``Retry-After`` is absent or unparseable.
 DEFAULT_RETRY_AFTER_SECONDS = 60
 
+# Upper bound (seconds) on how long a single 429 backoff may block. RFC 7231
+# permits ``Retry-After`` to be an arbitrarily far-future HTTP-date; without a
+# ceiling a spec-valid header could pin a worker for hours. 900s = 15 min.
+MAX_RETRY_AFTER_SECONDS = 900
+
 
 def _parse_retry_after(
     header_value: str | None, *, default: int = DEFAULT_RETRY_AFTER_SECONDS
@@ -150,9 +155,12 @@ def retry_on_failure(
                                     "attempts",
                                     retry_after=retry_after,
                                 ) from e
+                            # Cap the wait so a spec-valid but far-future
+                            # ``Retry-After`` can't block a worker indefinitely.
+                            sleep_seconds = min(retry_after, MAX_RETRY_AFTER_SECONDS)
                             logger.warning(
                                 "Rate limited, waiting %s seconds (attempt %d/%d)",
-                                retry_after,
+                                sleep_seconds,
                                 attempt + 1,
                                 max_attempts,
                                 extra={
@@ -160,15 +168,16 @@ def retry_on_failure(
                                     "attempt": attempt + 1,
                                     "max_attempts": max_attempts,
                                     "retry_after_seconds": retry_after,
+                                    "sleep_seconds": sleep_seconds,
                                     "status_code": status_code,
                                 },
                             )
                             _add_retry_event(
                                 attempt + 1,
-                                float(retry_after),
+                                float(sleep_seconds),
                                 status_code=status_code,
                             )
-                            time.sleep(retry_after)
+                            time.sleep(sleep_seconds)
                             continue
 
                         # Don't retry on client errors (except rate limiting)

--- a/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
+++ b/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
@@ -313,6 +313,27 @@ class TestStravaActivitiesRepo:
 
             assert m.call_count == api_config.activity_retry_attempts
 
+    def test_connection_error_translates_to_domain_error_not_leaked(
+        self, activities_repo, api_config
+    ):
+        """A network error that survives retries is translated to a domain
+        exception, never leaked as a raw ``requests`` exception across the
+        adapter boundary. This is what catching ``RequestException`` (not just
+        ``HTTPError``) covers — a ``ConnectionError``/``Timeout`` has no HTTP
+        response, so it maps to ``StravaApiError`` with ``status_code`` None.
+        """
+        activity_id = 12345678987654321
+        endpoint = f"{api_config.api_base_url}/activities/{activity_id}"
+        with Mocker() as m, patch("stravapipe.retry.time.sleep"):
+            m.get(endpoint, exc=requests.exceptions.ConnectionError("boom"))
+
+            with pytest.raises(StravaApiError) as exc_info:
+                activities_repo.read_activity_by_id(activity_id)
+
+        # Not a leaked requests exception; no HTTP response → status None.
+        assert not isinstance(exc_info.value, requests.exceptions.RequestException)
+        assert exc_info.value.status_code is None
+
 
 class TestStravaActivitiesRepoIntegration:
     """Integration tests using the full factory-created repo."""

--- a/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
+++ b/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
@@ -3,7 +3,7 @@
 Tests the layered architecture:
 - StravaTokenRepo: Token refresh via OAuth API
 - StravaTokenManager: Token state management
-- StravaApiClient: HTTP calls with 401 retry
+- StravaApiClient: HTTP calls with retry (5xx/429/network) + 401 refresh + error translation
 - StravaActivitiesRepo: Domain model conversion
 """
 
@@ -127,6 +127,28 @@ class TestStravaTokenRepo:
             # A 5xx on the token endpoint now actually retries inside the
             # decorator before the domain exception surfaces (H1).
             assert not isinstance(exc_info.value, StravaTokenError)
+            assert m.call_count == api_config.token_retry_attempts
+
+    def test_failed_request_429_raises_rate_limit_error(self, token_repo, api_config):
+        """A 429 on the token endpoint surfaces as StravaRateLimitError.
+
+        The retry decorator honors ``Retry-After`` and, on exhaustion, raises
+        ``StravaRateLimitError`` — which is *not* a ``StravaTokenError``/
+        ``StravaApiError``, so the breaker excludes it as a per-user rate-limit
+        signal instead of counting a token-endpoint 429 as a Strava outage.
+        """
+        with Mocker() as m, patch("stravapipe.retry.time.sleep"):
+            m.post(
+                api_config.token_url,
+                status_code=429,
+                headers={"Retry-After": "5"},
+                text="Too Many Requests",
+            )
+
+            with pytest.raises(StravaRateLimitError) as exc_info:
+                token_repo.refresh()
+
+            assert exc_info.value.retry_after == 5
             assert m.call_count == api_config.token_retry_attempts
 
 

--- a/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
+++ b/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import requests
 from requests_mock import Mocker
 
 from stravapipe.adapters.strava._repositories import (
@@ -36,6 +37,7 @@ from stravapipe.exceptions import (
     StravaRateLimitError,
     StravaTokenError,
 )
+from stravapipe.retry import MAX_RETRY_AFTER_SECONDS
 
 
 @pytest.fixture
@@ -116,11 +118,16 @@ class TestStravaTokenRepo:
                 token_repo.refresh()
 
     def test_failed_request_non_401(self, token_repo, api_config):
-        with Mocker() as m:
+        with Mocker() as m, patch("stravapipe.retry.time.sleep"):
             m.post(api_config.token_url, status_code=500, text="Server Error")
 
-            with pytest.raises(StravaApiError):
+            with pytest.raises(StravaApiError) as exc_info:
                 token_repo.refresh()
+
+            # A 5xx on the token endpoint now actually retries inside the
+            # decorator before the domain exception surfaces (H1).
+            assert not isinstance(exc_info.value, StravaTokenError)
+            assert m.call_count == api_config.token_retry_attempts
 
 
 class TestStravaTokenManager:
@@ -168,11 +175,16 @@ class TestStravaApiClient:
 
     def test_get_activity_api_error(self, api_client, api_config):
         activity_id = 12345678987654321
-        with Mocker() as m:
+        with Mocker() as m, patch("stravapipe.retry.time.sleep"):
             endpoint = f"{api_config.api_base_url}/activities/{activity_id}"
             m.get(endpoint, status_code=500, text="Server Error")
-            with pytest.raises(StravaApiError):
+            with pytest.raises(StravaApiError) as exc_info:
                 api_client.get_activity(activity_id)
+
+            # H1: a transient 5xx now retries inside the decorator
+            # (activity_retry_attempts) before surfacing as StravaApiError.
+            assert exc_info.value.status_code == 500
+            assert m.call_count == api_config.activity_retry_attempts
 
     def test_get_activity_401_refresh_and_retry_succeeds(
         self, token_manager_with_token, api_config, activity_json
@@ -215,6 +227,52 @@ class TestStravaApiClient:
             with pytest.raises(StravaTokenError):
                 api_client.get_activity(activity_id)
 
+    def test_get_activity_429_raises_rate_limit_error(self, api_client, api_config):
+        """A live 429 exhausts retries and surfaces StravaRateLimitError.
+
+        This drives the full path from the client entrypoint (not the
+        decorator in isolation), so it proves ``raise_for_status()`` now
+        feeds 429s into ``retry_on_failure`` and that PR #768's
+        ``_parse_retry_after`` is exercised on a real 429 (the parsed
+        ``Retry-After`` flows into both the sleep and the raised exception).
+        """
+        activity_id = 12345678987654321
+        with Mocker() as m, patch("stravapipe.retry.time.sleep") as mock_sleep:
+            endpoint = f"{api_config.api_base_url}/activities/{activity_id}"
+            m.get(endpoint, status_code=429, headers={"Retry-After": "5"})
+
+            with pytest.raises(StravaRateLimitError) as exc_info:
+                api_client.get_activity(activity_id)
+
+            # Every attempt hit the 429 before exhaustion.
+            assert m.call_count == api_config.activity_retry_attempts
+            # Parsed Retry-After drove the backoff (not the 60s default)...
+            mock_sleep.assert_called_with(5)
+            # ...and is reported on the exception.
+            assert exc_info.value.retry_after == 5
+
+    def test_get_activity_429_retry_after_is_clamped(self, api_client, api_config):
+        """A far-future Retry-After is clamped to the ceiling for the sleep.
+
+        The server's raw requested delay is still reported on the exception,
+        but ``time.sleep`` is bounded so a spec-valid header can't pin a
+        worker for hours.
+        """
+        activity_id = 12345678987654321
+        with Mocker() as m, patch("stravapipe.retry.time.sleep") as mock_sleep:
+            endpoint = f"{api_config.api_base_url}/activities/{activity_id}"
+            m.get(endpoint, status_code=429, headers={"Retry-After": "100000"})
+
+            with pytest.raises(StravaRateLimitError) as exc_info:
+                api_client.get_activity(activity_id)
+
+            # Every sleep is clamped to the ceiling, never the raw value.
+            assert mock_sleep.call_args_list  # at least one backoff happened
+            for call in mock_sleep.call_args_list:
+                assert call.args[0] == MAX_RETRY_AFTER_SECONDS
+            # The exception still carries the server's raw requested delay.
+            assert exc_info.value.retry_after == 100000
+
 
 class TestStravaActivitiesRepo:
     def test_read_activity_by_id(self, activities_repo, activity_json, api_config):
@@ -236,6 +294,24 @@ class TestStravaActivitiesRepo:
             resp = activities_repo.read_activity_by_id(activity_id)
 
         assert isinstance(resp, DetailedStravaActivity)
+
+    def test_read_activity_by_id_500_retries_then_raises(
+        self, activities_repo, api_config
+    ):
+        """Behavioral (from the repo entrypoint): a 5xx retries N times.
+
+        Exercises ``read_activity_by_id`` with the HTTP layer mocked so the
+        retry is proven end-to-end, not just at the decorator boundary.
+        """
+        activity_id = 12345678987654321
+        endpoint = f"{api_config.api_base_url}/activities/{activity_id}"
+        with Mocker() as m, patch("stravapipe.retry.time.sleep"):
+            m.get(endpoint, status_code=500, text="Server Error")
+
+            with pytest.raises(StravaApiError):
+                activities_repo.read_activity_by_id(activity_id)
+
+            assert m.call_count == api_config.activity_retry_attempts
 
 
 class TestStravaActivitiesRepoIntegration:
@@ -428,6 +504,45 @@ class TestStravaApiClientListActivities:
         assert len(result) == 1
         assert token_manager_with_token._current_access_token == "new_token"
 
+    def test_list_activities_500_raises_strava_api_error(self, api_client, api_config):
+        """M1: a 5xx on the list endpoint raises a domain exception.
+
+        Before this fix ``list_activities`` called a bare
+        ``resp.raise_for_status()``, leaking ``requests.HTTPError`` across
+        the adapter boundary. It must now surface ``StravaApiError`` — and
+        never a raw ``requests`` exception.
+        """
+        endpoint = f"{api_config.api_base_url}{self.LIST_PATH}"
+        with Mocker() as m, patch("stravapipe.retry.time.sleep"):
+            m.get(endpoint, status_code=500, text="Server Error")
+
+            with pytest.raises(StravaApiError) as exc_info:
+                api_client.list_activities(before=1700000000, after=1690000000, page=1)
+
+            # Domain exception, not a leaked requests.HTTPError (M1).
+            assert not isinstance(exc_info.value, requests.exceptions.HTTPError)
+            assert exc_info.value.status_code == 500
+            # H1: the transient 5xx retried inside the decorator first.
+            assert m.call_count == api_config.activity_retry_attempts
+
+    def test_list_activities_401_after_refresh_raises_token_error(
+        self, token_manager_with_token, api_config
+    ):
+        """A persistent 401 on the list path surfaces StravaTokenError.
+
+        Confirms the shared error translation (M1) preserves the 401 →
+        refresh-once → StravaTokenError contract on the list path too.
+        """
+        client = StravaApiClient(token_manager_with_token, api_config)
+        endpoint = f"{api_config.api_base_url}{self.LIST_PATH}"
+
+        with Mocker() as m:
+            m.get(endpoint, status_code=401)
+            m.post(api_config.token_url, json={"access_token": "new_token"})
+
+            with pytest.raises(StravaTokenError):
+                client.list_activities(before=1700000000, after=1690000000, page=1)
+
 
 # =============================================================================
 # StravaActivitiesRepo - read_standard_activity_by_id tests
@@ -524,6 +639,27 @@ class TestStravaActivitiesRepoByYear:
 
         assert result == []
 
+    def test_read_activities_by_year_500_retries_then_raises(
+        self, activities_repo, api_config
+    ):
+        """Behavioral (from the repo entrypoint): a 5xx mid-list retries.
+
+        Drives ``read_activities_by_year`` — the backfill entrypoint — with
+        the HTTP layer mocked, so it catches the exact regression the
+        decorator-in-isolation unit tests missed: without ``raise_for_status``
+        the 5xx never reached ``retry_on_failure`` and the year was discarded
+        on the first transient blip.
+        """
+        endpoint = f"{api_config.api_base_url}{self.LIST_PATH}"
+        with Mocker() as m, patch("stravapipe.retry.time.sleep"):
+            m.get(endpoint, status_code=500, text="Server Error")
+
+            with pytest.raises(StravaApiError):
+                activities_repo.read_activities_by_year(2025)
+
+            # The list call retried the transient 5xx N times before failing.
+            assert m.call_count == api_config.activity_retry_attempts
+
 
 class TestStravaCircuitBreaker:
     """Circuit-breaker behavior on the shared Strava breaker.
@@ -604,7 +740,14 @@ class TestStravaCircuitBreaker:
         test by orders of magnitude.
         """
         breaker = create_strava_breaker(fail_max=5, reset_timeout=60)
-        client = self._build_client(token_manager_with_token, api_config, breaker)
+        # Pin activity_retry_attempts=1 so each get_activity makes exactly one
+        # HTTP call. `_fetch` now raises on 5xx (H1), so with the default 3
+        # attempts each failing get_activity would consume three responses and
+        # the fixed response list below would no longer line up 1:1 with
+        # breaker failures. One attempt keeps this test about breaker
+        # recovery, not retry counting (that's covered elsewhere).
+        cfg = api_config._replace(activity_retry_attempts=1)
+        client = self._build_client(token_manager_with_token, cfg, breaker)
         activity_id = activity_json["id"]
 
         with (
@@ -613,11 +756,8 @@ class TestStravaCircuitBreaker:
             patch("stravapipe.retry.random.uniform", side_effect=lambda _a, _b: 0),
         ):
             endpoint = f"{api_config.api_base_url}/activities/{activity_id}"
-            # `_fetch` returns the requests.Response without raising on
-            # 5xx, so @retry_on_failure never sees an exception — each
-            # get_activity makes exactly ONE HTTP call, not three. 5
-            # breaker failures = 5 hits at 500; the 6th hit is the
-            # half-open probe and returns 200.
+            # With one attempt per call, 5 breaker failures = 5 hits at 500;
+            # the 6th hit is the half-open probe and returns 200.
             down = {"status_code": 500, "text": "Server Error"}
             up = {"json": activity_json, "status_code": 200}
             m.get(endpoint, [down] * 5 + [up])


### PR DESCRIPTION


requests.get()/post() don't raise on 4xx/5xx unless raise_for_status() is called, and none of the three decorated _fetch/_refresh bodies called it inside the retried scope. So retry_on_failure's entire HTTPError branch was unreachable: only network errors ever retried. That meant no in-process retry for transient 5xx, Retry-After ignored on 429, StravaRateLimitError never raised (its circuit-breaker exclude contract silently void), and no transient backstop for backfill.

H1: call resp.raise_for_status() at the end of each decorated _fetch/_refresh so 5xx/429 raise HTTPError INTO the decorator. Rework the post-call handling that assumed a returned Response (resp.ok checks, _handle_error_response, the 401 token-refresh recursion) to catch HTTPError and key off exc.response.status_code. Behavior preserved exactly: 404 -> ActivityNotFoundError, 401 -> refresh once then StravaTokenError, 429 -> StravaRateLimitError. A 429 surfaces from the decorator as StravaRateLimitError (not an HTTPError), so it propagates past _handle_error_response and keeps the breaker exclude contract.

M1: route list_activities errors through the same domain-exception translation as get_activity by generalizing _handle_error_response(activity_id=None), so a list failure raises StravaApiError/StravaTokenError instead of a bare requests.HTTPError across the adapter boundary. This also unifies the 401 refresh-and-retry recursion (previously duplicated inline in the list path).

Also clamp the 429 backoff: min(retry_after, MAX_RETRY_AFTER_SECONDS=900) so a spec-valid far-future Retry-After (HTTP-date form) can't pin a worker for hours.

Tests: behavioral tests from the repo entrypoints (read_activity_by_id, read_activities_by_year) and the client entrypoints assert a 500 retries N times with the HTTP layer mocked (the gap that let this bug hide); a list 500 raises StravaApiError not HTTPError; a list 401-after-refresh raises StravaTokenError; a live 429 exhausts to StravaRateLimitError with the parsed Retry-After driving the sleep and reported on the exception (exercising _parse_retry_after on a real 429 path); and the far-future Retry-After is clamped. Pin activity_retry_attempts=1 in the breaker-recovery test whose fixed response list assumed the old non-raising behavior.