### PR TITLE
refactor(stravapipe): give the token endpoint its own circuit breaker

### DIFF
--- a/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
+++ b/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
@@ -10,12 +10,15 @@ This module provides a layered architecture for Strava API access:
            ↓
     StravaActivitiesRepo - Domain model conversion
 
-A single ``pybreaker.CircuitBreaker`` is shared across ``StravaTokenRepo``
-and ``StravaApiClient`` — outbound traffic to Strava goes through one
-breaker so an outage trips it once and fails-fast for every concurrent
-caller until the dependency recovers. The breaker wraps the retry loop
-(not vice versa) per Microsoft's combined-pattern guidance; matches the
-Go side in ``packages/dispatcher/adapters/strava/client.go``.
+``StravaTokenRepo`` and ``StravaApiClient`` each get their own
+``pybreaker.CircuitBreaker``: the OAuth-token and activities endpoints are
+distinct Strava subsystems that fail independently, so an outage on one must
+not fail-fast the other. Separate breakers also mean a token fault surfacing
+during an activity 401-refresh — the token refresh is a breaker call nested
+inside the activity breaker call — counts once on the token breaker rather
+than twice on a shared one. Each breaker wraps the retry loop (not vice versa)
+per Microsoft's combined-pattern guidance; matches the Go side in
+``packages/dispatcher/adapters/strava/client.go``.
 """
 
 from collections.abc import Callable, Sequence
@@ -97,7 +100,7 @@ def create_strava_breaker(
     fail_max: int = _BREAKER_FAILURE_THRESHOLD,
     reset_timeout: int = _BREAKER_RESET_TIMEOUT_SECONDS,
 ) -> pybreaker.CircuitBreaker:
-    """Build the shared Strava circuit breaker.
+    """Build a Strava circuit breaker.
 
     ``fail_max`` / ``reset_timeout`` are parameterized so tests can use
     short values; production callers should rely on the defaults. The
@@ -677,7 +680,6 @@ class StravaActivitiesRepo(ReadDetailedActivities, ReadStandardActivities):
 def create_strava_activities_repo(
     tokens: StravaTokenSet,
     api_config: StravaApiConfig | None = None,
-    breaker: pybreaker.CircuitBreaker | None = None,
 ) -> StravaActivitiesRepo:
     """Create a fully-wired StravaActivitiesRepo.
 
@@ -688,23 +690,22 @@ def create_strava_activities_repo(
         tokens: Strava OAuth tokens (client_id, client_secret, refresh_token,
                 and optionally access_token)
         api_config: Optional API configuration (URLs, timeouts, retry settings)
-        breaker: Optional circuit breaker. Defaults to a fresh shared
-            instance — production code generally wants the default since
-            each composition root creates a long-lived repo and the
-            breaker state should live for the process lifetime. Tests
-            can pass a breaker with a short ``reset_timeout``.
 
     Returns:
         Configured StravaActivitiesRepo ready for use
     """
     config = api_config or StravaApiConfig()
-    # One breaker shared across the token-refresh and API-call paths
-    # so an outage trips it once for the entire Strava dependency.
-    shared_breaker = breaker if breaker is not None else create_strava_breaker()
+    # Separate breakers per Strava endpoint domain. The OAuth-token and the
+    # activities endpoints fail independently, so an outage on one shouldn't
+    # trip the other; separate breakers also mean a token fault surfacing during
+    # an activity 401-refresh (a breaker call nested inside the activity breaker
+    # call) counts once on the token breaker, not twice on a shared one.
+    token_breaker = create_strava_breaker()
+    activities_breaker = create_strava_breaker()
 
     # Build the dependency chain
-    token_repo = StravaTokenRepo(tokens, config, breaker=shared_breaker)
+    token_repo = StravaTokenRepo(tokens, config, breaker=token_breaker)
     token_manager = StravaTokenManager(token_repo, tokens.access_token)
-    api_client = StravaApiClient(token_manager, config, breaker=shared_breaker)
+    api_client = StravaApiClient(token_manager, config, breaker=activities_breaker)
 
     return StravaActivitiesRepo(api_client)

--- a/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
+++ b/packages/stravapipe/src/stravapipe/adapters/strava/_repositories.py
@@ -99,11 +99,15 @@ def create_strava_breaker(
     *,
     fail_max: int = _BREAKER_FAILURE_THRESHOLD,
     reset_timeout: int = _BREAKER_RESET_TIMEOUT_SECONDS,
+    name: str = "strava-api",
 ) -> pybreaker.CircuitBreaker:
     """Build a Strava circuit breaker.
 
     ``fail_max`` / ``reset_timeout`` are parameterized so tests can use
-    short values; production callers should rely on the defaults. The
+    short values; production callers should rely on the defaults. ``name``
+    labels the breaker in ``_BreakerLogger`` output — the factory gives the
+    token and activities breakers distinct names so a state-change log shows
+    which one tripped. The
     ``exclude`` list captures per-request signals that should NOT count
     toward Strava-side health — 404 (per-activity), 401 (per-user
     token), 429 (per-user rate limit). Everything else (5xx, network,
@@ -129,7 +133,7 @@ def create_strava_breaker(
         reset_timeout=reset_timeout,
         exclude=[ActivityNotFoundError, StravaTokenError, StravaRateLimitError],
         listeners=[_BreakerLogger()],
-        name="strava-api",
+        name=name,
     )
 
 
@@ -700,8 +704,8 @@ def create_strava_activities_repo(
     # trip the other; separate breakers also mean a token fault surfacing during
     # an activity 401-refresh (a breaker call nested inside the activity breaker
     # call) counts once on the token breaker, not twice on a shared one.
-    token_breaker = create_strava_breaker()
-    activities_breaker = create_strava_breaker()
+    token_breaker = create_strava_breaker(name="strava-token")
+    activities_breaker = create_strava_breaker(name="strava-activities")
 
     # Build the dependency chain
     token_repo = StravaTokenRepo(tokens, config, breaker=token_breaker)

--- a/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
+++ b/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
@@ -832,6 +832,11 @@ class TestStravaCircuitBreaker:
         activities_breaker = repo._client._breaker
         token_breaker = repo._client._token_manager._token_repo._breaker
         assert activities_breaker is not token_breaker
+        # Distinct names so a _BreakerLogger state-change log shows which tripped.
+        assert {token_breaker.name, activities_breaker.name} == {
+            "strava-token",
+            "strava-activities",
+        }
 
     def test_token_fault_during_401_refresh_counts_once_per_breaker(
         self, tokenset_with_access, api_config

--- a/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
+++ b/packages/stravapipe/tests/unit/adapters/strava/test_repositories.py
@@ -819,19 +819,41 @@ class TestStravaCircuitBreaker:
             assert result["id"] == activity_id
             assert breaker.current_state == "closed"
 
-    def test_shared_breaker_across_token_and_api_paths(
+    def test_factory_wires_separate_breakers_for_token_and_api(
         self, tokenset_with_access, api_config
     ):
-        """Failures at the token endpoint trip the same breaker the API uses.
+        """The factory gives the token and activity paths independent breakers.
 
-        Verifies the factory wires one breaker into both StravaTokenRepo
-        and StravaApiClient — an outage on either endpoint short-circuits
-        both paths.
+        Previously one breaker was shared across both; now each Strava endpoint
+        domain (OAuth token vs activities) gets its own, so an outage on one
+        doesn't fail-fast the other.
         """
-        breaker = create_strava_breaker(fail_max=2, reset_timeout=60)
-        repo = create_strava_activities_repo(
-            tokenset_with_access, api_config, breaker=breaker
+        repo = create_strava_activities_repo(tokenset_with_access, api_config)
+        activities_breaker = repo._client._breaker
+        token_breaker = repo._client._token_manager._token_repo._breaker
+        assert activities_breaker is not token_breaker
+
+    def test_token_fault_during_401_refresh_counts_once_per_breaker(
+        self, tokenset_with_access, api_config
+    ):
+        """A token fault during an activity 401-refresh counts once per breaker.
+
+        The token refresh is a breaker call nested inside the activity breaker
+        call. With separate breakers the token 5xx counts once on the token
+        breaker and the failed activity call counts once on the activities
+        breaker — so a single ``get_activity`` leaves both ``fail_max=2``
+        breakers closed. A shared breaker would have counted the token fault
+        twice and already be open.
+        """
+        token_breaker = create_strava_breaker(fail_max=2, reset_timeout=60)
+        activities_breaker = create_strava_breaker(fail_max=2, reset_timeout=60)
+        token_repo = StravaTokenRepo(
+            tokens=tokenset_with_access, api_config=api_config, breaker=token_breaker
         )
+        token_manager = StravaTokenManager(
+            token_repo, tokenset_with_access.access_token
+        )
+        client = StravaApiClient(token_manager, api_config, breaker=activities_breaker)
         activity_id = 33333
 
         with (
@@ -839,23 +861,26 @@ class TestStravaCircuitBreaker:
             patch("stravapipe.retry.time.sleep"),
             patch("stravapipe.retry.random.uniform", side_effect=lambda _a, _b: 0),
         ):
-            endpoint = f"{api_config.api_base_url}/activities/{activity_id}"
-            # Two API failures trip the (fail_max=2) breaker.
-            m.get(endpoint, status_code=500, text="Server Error")
-            for _ in range(2):
-                with pytest.raises(StravaApiError):
-                    repo.read_activity_by_id(activity_id)
-            assert breaker.current_state == "open"
-
-            # Token refresh through the SAME breaker also fail-fasts.
-            m.post(api_config.token_url, json={"access_token": "x"})
-            token_repo = StravaTokenRepo(
-                tokens=tokenset_with_access, api_config=api_config, breaker=breaker
+            # Activity 401 triggers a token refresh; the token endpoint is down.
+            m.get(
+                f"{api_config.api_base_url}/activities/{activity_id}",
+                status_code=401,
+                text="Unauthorized",
             )
-            with pytest.raises(StravaApiError) as exc_info:
-                token_repo.refresh()
-            assert exc_info.value.status_code == 503
-            assert "circuit breaker open" in str(exc_info.value)
+            m.post(api_config.token_url, status_code=503, text="oauth down")
+
+            with pytest.raises(StravaApiError):
+                client.get_activity(activity_id)
+
+            # One call: each breaker counted exactly one failure (still closed).
+            assert token_breaker.current_state == "closed"
+            assert activities_breaker.current_state == "closed"
+
+            # A second identical call reaches fail_max=2 on each.
+            with pytest.raises(StravaApiError):
+                client.get_activity(activity_id)
+            assert token_breaker.current_state == "open"
+            assert activities_breaker.current_state == "open"
 
     def test_token_endpoint_5xx_counts_as_failure(self, tokenset, api_config):
         """A 5xx on /oauth/token must count toward the breaker.


### PR DESCRIPTION
StravaTokenRepo and StravaApiClient shared one breaker, so a token-endpoint fault surfacing during an activity 401-refresh (a breaker call nested inside the activity breaker call) was counted twice on that single breaker. The OAuth-token and activities endpoints are distinct Strava subsystems that fail independently, so give each its own breaker: an outage on one no longer fail-fasts the other, and a token fault during a 401-refresh now counts once on the token breaker (plus once on the activities breaker for the failed activity call) instead of twice on one.

Drops the now-meaningless breaker param from create_strava_activities_repo (no production caller used it; the factory builds both). Updates the module docstring and splits the one factory-injection test into a factory-separation test and a counts-once behavioral test.