### PR TITLE
feat(ratelimit): meter rate-limit rejections and exempt dispatcher probes

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -256,6 +256,7 @@ resolution for custom metrics).
 |---|---|---|---|
 | `webhook/events` | dispatcher, bq-inserter, postgres-writer | `aspect_type`, `object_type` | Webhook events processed |
 | `webhook/owner_check` | dispatcher | `result=allowed\|stray\|orphan\|error` | Allowlist outcomes |
+| `ratelimit/rejected` | apigateway, dispatcher | `reason=over_limit\|map_full`, `limiter=default\|auth\|tile\|dispatcher` | Requests rejected (429) by the per-IP rate limiter. `over_limit` = the IP's token bucket is empty; `map_full` = the per-IP client map is at `MaxClients`. Rejections short-circuit before `HTTPRequestLoggerWithMetrics`, so this counter (not the request-duration histogram) is the app-level signal for rate-limiting. |
 
 ### Gauges
 

--- a/packages/apigateway/cmd/apigateway/main.go
+++ b/packages/apigateway/cmd/apigateway/main.go
@@ -294,10 +294,12 @@ func initDependencies(ctx context.Context, cfg *config.Config, log *slog.Logger,
 	// traffic is bursty by nature (a slippy-map viewport pulls many tiles at once),
 	// so without this skip a normal pan/zoom would blow past burst 20 and 429.
 	// Tiles get their own limiter (8c) tuned for that profile.
-	deps.rateLimiter = ratelimit.New(ctx, ratelimit.Config{
+	deps.rateLimiter = ratelimit.New(ctx, &ratelimit.Config{
 		Rate:  10,
 		Burst: 20,
 		Skip:  server.IsTileRequest,
+		Name:  "default",
+		Meter: meter,
 	}, log)
 
 	// 8b. Initialize auth-scoped rate limiter. /auth/* endpoints are the most
@@ -306,9 +308,11 @@ func initDependencies(ctx context.Context, cfg *config.Config, log *slog.Logger,
 	// 10/min per IP is well above any legitimate pattern and well below probing
 	// rates. Hard-coded for now since it's not security-load-bearing; revisit if
 	// tuning becomes a thing.
-	deps.authRateLimiter = ratelimit.New(ctx, ratelimit.Config{
+	deps.authRateLimiter = ratelimit.New(ctx, &ratelimit.Config{
 		Rate:  10.0 / 60.0, // 10 per minute
 		Burst: 5,           // allow a small burst for retries
+		Name:  "auth",
+		Meter: meter,
 	}, log)
 
 	// 8c. Tile rate limiter. The MVT tile route has a different request profile
@@ -320,9 +324,11 @@ func initDependencies(ctx context.Context, cfg *config.Config, log *slog.Logger,
 	// Decision (see planning task): rate-limit rather than HTTP-cache for now — the
 	// /v1 group sets NoCacheHeaders, so tile caching warrants its own deliberate
 	// pass later; this fix is purely the limiter mismatch.
-	deps.tileRateLimiter = ratelimit.New(ctx, ratelimit.Config{
+	deps.tileRateLimiter = ratelimit.New(ctx, &ratelimit.Config{
 		Rate:  30,  // sustained tiles/sec per IP — far above human pan/zoom
 		Burst: 150, // absorbs a full zoomed-out viewport's tile fan-out
+		Name:  "tile",
+		Meter: meter,
 	}, log)
 
 	// 9. Initialize PostgreSQL repository (required dependency)

--- a/packages/apigateway/handler_test.go
+++ b/packages/apigateway/handler_test.go
@@ -193,10 +193,10 @@ func TestTileRateLimitScopingAndCORS(t *testing.T) {
 	defer cancel()
 
 	// Tile limiter that always rejects (burst 0) so we can assert the 429 path.
-	tileLimiter := ratelimit.New(ctx, ratelimit.Config{Rate: 0.001, Burst: 0}, logger)
+	tileLimiter := ratelimit.New(ctx, &ratelimit.Config{Rate: 0.001, Burst: 0}, logger)
 	// Global limiter that never rejects but skips tiles — mirrors prod wiring, so
 	// this also proves the global Skip hook routes tiles to the tile limiter.
-	globalLimiter := ratelimit.New(ctx, ratelimit.Config{
+	globalLimiter := ratelimit.New(ctx, &ratelimit.Config{
 		Rate: 1000, Burst: 1000, Skip: server.IsTileRequest,
 	}, logger)
 

--- a/packages/apigateway/internal/server/router.go
+++ b/packages/apigateway/internal/server/router.go
@@ -106,10 +106,14 @@ func NewRouter(cfg RouterConfig, public PublicRoutes, auth AuthenticatedRoutes, 
 	r.Use(chiMiddleware.RequestID)
 	r.Use(gcplog.BridgeRequestID)
 	r.Use(gcplog.CloudRunRealIP)
+	// WithCloudTraceContext before the global rate limiter so a 429 rejection's
+	// logs still carry trace + request-id correlation. The limiter stays before
+	// HTTPRequestLoggerWithMetrics below, preserving the latency-histogram hygiene.
+	// (The auth/tile limiters run in their sub-groups below, already after this.)
+	r.Use(gcplog.WithCloudTraceContext)
 	if cfg.RateLimiter != nil {
 		r.Use(cfg.RateLimiter.Middleware)
 	}
-	r.Use(gcplog.WithCloudTraceContext)
 	r.Use(otel.SpanNameFromChiRoute)
 	r.Use(otel.StampRequestID)
 	// Stamp X-Trace-Id on every response so the frontend can correlate a

--- a/packages/apigateway/internal/server/router.go
+++ b/packages/apigateway/internal/server/router.go
@@ -106,14 +106,10 @@ func NewRouter(cfg RouterConfig, public PublicRoutes, auth AuthenticatedRoutes, 
 	r.Use(chiMiddleware.RequestID)
 	r.Use(gcplog.BridgeRequestID)
 	r.Use(gcplog.CloudRunRealIP)
-	// WithCloudTraceContext before the global rate limiter so a 429 rejection's
-	// logs still carry trace + request-id correlation. The limiter stays before
-	// HTTPRequestLoggerWithMetrics below, preserving the latency-histogram hygiene.
-	// (The auth/tile limiters run in their sub-groups below, already after this.)
-	r.Use(gcplog.WithCloudTraceContext)
 	if cfg.RateLimiter != nil {
 		r.Use(cfg.RateLimiter.Middleware)
 	}
+	r.Use(gcplog.WithCloudTraceContext)
 	r.Use(otel.SpanNameFromChiRoute)
 	r.Use(otel.StampRequestID)
 	// Stamp X-Trace-Id on every response so the frontend can correlate a

--- a/packages/apigateway/internal/server/server_test.go
+++ b/packages/apigateway/internal/server/server_test.go
@@ -410,7 +410,7 @@ func TestNewRouter_AuthRateLimiterScopedToAuth(t *testing.T) {
 	auth := &mockAuthMiddleware{}
 
 	// Auth limiter: 1 req/s, burst 1 — second hit in quick succession is rejected.
-	authLimiter := ratelimit.New(ctx, ratelimit.Config{
+	authLimiter := ratelimit.New(ctx, &ratelimit.Config{
 		Rate:            1,
 		Burst:           1,
 		CleanupInterval: time.Hour,
@@ -418,7 +418,7 @@ func TestNewRouter_AuthRateLimiterScopedToAuth(t *testing.T) {
 	}, logger)
 
 	// Global limiter: high rate so it doesn't interfere with the test.
-	globalLimiter := ratelimit.New(ctx, ratelimit.Config{
+	globalLimiter := ratelimit.New(ctx, &ratelimit.Config{
 		Rate:            1000,
 		Burst:           1000,
 		CleanupInterval: time.Hour,

--- a/packages/dispatcher/adapters/http/handler.go
+++ b/packages/dispatcher/adapters/http/handler.go
@@ -157,6 +157,11 @@ func (h *Handler) RegisterRoutes() http.Handler {
 	r.Use(chiMiddleware.RequestID)
 	r.Use(gcplog.BridgeRequestID)
 	r.Use(gcplog.CloudRunRealIP)
+	// WithCloudTraceContext before the rate limiter so a 429 rejection's logs still
+	// carry the trace + request-id correlation. The limiter stays before
+	// HTTPRequestLoggerWithMetrics below, so a fast reject still never pollutes the
+	// latency histogram.
+	r.Use(gcplog.WithCloudTraceContext)
 	if h.rateLimiter != nil {
 		// 429 rejections short-circuit here, before HTTPRequestLoggerWithMetrics —
 		// by design, so a fast reject doesn't pollute the latency histogram. The
@@ -164,7 +169,6 @@ func (h *Handler) RegisterRoutes() http.Handler {
 		// counter instead.
 		r.Use(h.rateLimiter.Middleware)
 	}
-	r.Use(gcplog.WithCloudTraceContext)
 	r.Use(sharedotel.StampRequestID)
 	r.Use(gcplog.HTTPRequestLoggerWithMetrics(h.logger, h.httpHistogram))
 	r.Use(chiMiddleware.Recoverer)

--- a/packages/dispatcher/adapters/http/handler.go
+++ b/packages/dispatcher/adapters/http/handler.go
@@ -158,6 +158,10 @@ func (h *Handler) RegisterRoutes() http.Handler {
 	r.Use(gcplog.BridgeRequestID)
 	r.Use(gcplog.CloudRunRealIP)
 	if h.rateLimiter != nil {
+		// 429 rejections short-circuit here, before HTTPRequestLoggerWithMetrics —
+		// by design, so a fast reject doesn't pollute the latency histogram. The
+		// limiter self-reports rejections via its desirelines.io/ratelimit/rejected
+		// counter instead.
 		r.Use(h.rateLimiter.Middleware)
 	}
 	r.Use(gcplog.WithCloudTraceContext)

--- a/packages/dispatcher/adapters/http/handler.go
+++ b/packages/dispatcher/adapters/http/handler.go
@@ -157,11 +157,6 @@ func (h *Handler) RegisterRoutes() http.Handler {
 	r.Use(chiMiddleware.RequestID)
 	r.Use(gcplog.BridgeRequestID)
 	r.Use(gcplog.CloudRunRealIP)
-	// WithCloudTraceContext before the rate limiter so a 429 rejection's logs still
-	// carry the trace + request-id correlation. The limiter stays before
-	// HTTPRequestLoggerWithMetrics below, so a fast reject still never pollutes the
-	// latency histogram.
-	r.Use(gcplog.WithCloudTraceContext)
 	if h.rateLimiter != nil {
 		// 429 rejections short-circuit here, before HTTPRequestLoggerWithMetrics —
 		// by design, so a fast reject doesn't pollute the latency histogram. The
@@ -169,6 +164,7 @@ func (h *Handler) RegisterRoutes() http.Handler {
 		// counter instead.
 		r.Use(h.rateLimiter.Middleware)
 	}
+	r.Use(gcplog.WithCloudTraceContext)
 	r.Use(sharedotel.StampRequestID)
 	r.Use(gcplog.HTTPRequestLoggerWithMetrics(h.logger, h.httpHistogram))
 	r.Use(chiMiddleware.Recoverer)

--- a/packages/dispatcher/cmd/dispatcher/main.go
+++ b/packages/dispatcher/cmd/dispatcher/main.go
@@ -248,9 +248,17 @@ func initDependencies(cfg *config.Config, log *slog.Logger, meter metric.Meter, 
 	// Rate limiter: 5 req/s, burst 10 (Strava sends a few events/day normally)
 	// Uses Background context (not startupCtx) because the cleanup goroutine must
 	// run for the lifetime of the process — startupCtx is canceled after 10s.
-	rateLimiter := ratelimit.New(context.Background(), ratelimit.Config{
+	rateLimiter := ratelimit.New(context.Background(), &ratelimit.Config{
 		Rate:  5,
 		Burst: 10,
+		Name:  "dispatcher",
+		Meter: meter,
+		// Exempt liveness/health probes so GCP uptime checks + Cloud Run probes
+		// (every ~60s, from many regional IPs) never consume rate-limit tokens.
+		// Mirrors requestLogger's probe-path exclusion.
+		Skip: func(r *http.Request) bool {
+			return r.URL.Path == "/health" || (r.Method == http.MethodHead && r.URL.Path == "/")
+		},
 	}, log)
 
 	handler := httpadapter.NewHandler(publisher, deauthPublisher, secretProvider, stravaClient, tokenStore, allowChecker, log, &httpadapter.HandlerConfig{

--- a/packages/shared/ratelimit/ratelimit.go
+++ b/packages/shared/ratelimit/ratelimit.go
@@ -92,6 +92,12 @@ type Limiter struct {
 // New creates a Limiter and starts a background goroutine that removes stale entries.
 // The cleanup goroutine stops when ctx is canceled.
 func New(ctx context.Context, cfg *Config, logger *slog.Logger) *Limiter {
+	// cfg is required (a nil-deref here is a clear fail-fast for a misconfigured
+	// caller); the project's linter forbids an explicit panic and an error return
+	// would ripple through every composition root. Default a missing logger.
+	if logger == nil {
+		logger = slog.Default()
+	}
 	l := &Limiter{
 		clients:    make(map[string]*entry),
 		rate:       rate.Limit(cfg.Rate),

--- a/packages/shared/ratelimit/ratelimit.go
+++ b/packages/shared/ratelimit/ratelimit.go
@@ -131,6 +131,14 @@ func (l *Limiter) recordRejected(ctx context.Context, reason string) {
 	))
 }
 
+// reject writes the standard 429 response: the Retry-After header, the
+// desirelines.io/ratelimit/rejected metric (by reason), and the JSON error body.
+func (l *Limiter) reject(w http.ResponseWriter, r *http.Request, retryAfter, reason string) {
+	w.Header().Set("Retry-After", retryAfter)
+	l.recordRejected(r.Context(), reason)
+	apierrors.WriteError(w, r, apierrors.ErrRateLimited, l.logger)
+}
+
 // Middleware returns chi-compatible middleware that rejects requests exceeding the rate limit.
 // It expects gcplog.CloudRunRealIP to have already run so that r.RemoteAddr contains the real client IP.
 func (l *Limiter) Middleware(next http.Handler) http.Handler {
@@ -146,9 +154,7 @@ func (l *Limiter) Middleware(next http.Handler) http.Handler {
 
 		limiter := l.getLimiter(ip)
 		if limiter == nil {
-			l.recordRejected(r.Context(), "map_full")
-			w.Header().Set("Retry-After", "60")
-			apierrors.WriteError(w, r, apierrors.ErrRateLimited, l.logger)
+			l.reject(w, r, "60", "map_full")
 			return
 		}
 
@@ -179,9 +185,7 @@ func (l *Limiter) Middleware(next http.Handler) http.Handler {
 			retryAfter = fmt.Sprintf("%.0f", seconds)
 		}
 
-		w.Header().Set("Retry-After", retryAfter)
-		l.recordRejected(r.Context(), "over_limit")
-		apierrors.WriteError(w, r, apierrors.ErrRateLimited, l.logger)
+		l.reject(w, r, retryAfter, "over_limit")
 	})
 }
 

--- a/packages/shared/ratelimit/ratelimit.go
+++ b/packages/shared/ratelimit/ratelimit.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/andy-esch/desirelines/packages/shared/apierrors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/time/rate"
 )
 
@@ -36,23 +38,30 @@ type Config struct {
 	// exempt a route class with a different request profile — e.g. bursty MVT
 	// map tiles — from a limiter without restructuring the middleware chain.
 	Skip func(*http.Request) bool
+	// Name labels this limiter in the desirelines.io/ratelimit/rejected metric
+	// (the "limiter" attribute), so a process running several limiters — e.g. the
+	// apigateway's default/auth/tile — can tell which one is rejecting.
+	Name string
+	// Meter, when non-nil, is used to create the rejection counter. When nil the
+	// limiter simply doesn't emit the metric (tests, or callers without OTel).
+	Meter metric.Meter
 }
 
-func (c Config) maxClients() int {
+func (c *Config) maxClients() int {
 	if c.MaxClients > 0 {
 		return c.MaxClients
 	}
 	return defaultMaxClients
 }
 
-func (c Config) cleanupInterval() time.Duration {
+func (c *Config) cleanupInterval() time.Duration {
 	if c.CleanupInterval > 0 {
 		return c.CleanupInterval
 	}
 	return time.Minute
 }
 
-func (c Config) ttl() time.Duration {
+func (c *Config) ttl() time.Duration {
 	if c.TTL > 0 {
 		return c.TTL
 	}
@@ -76,11 +85,13 @@ type Limiter struct {
 	ttl        time.Duration
 	skip       func(*http.Request) bool
 	logger     *slog.Logger
+	name       string
+	rejected   metric.Int64Counter
 }
 
 // New creates a Limiter and starts a background goroutine that removes stale entries.
 // The cleanup goroutine stops when ctx is canceled.
-func New(ctx context.Context, cfg Config, logger *slog.Logger) *Limiter {
+func New(ctx context.Context, cfg *Config, logger *slog.Logger) *Limiter {
 	l := &Limiter{
 		clients:    make(map[string]*entry),
 		rate:       rate.Limit(cfg.Rate),
@@ -89,10 +100,35 @@ func New(ctx context.Context, cfg Config, logger *slog.Logger) *Limiter {
 		ttl:        cfg.ttl(),
 		skip:       cfg.Skip,
 		logger:     logger,
+		name:       cfg.Name,
+	}
+	if cfg.Meter != nil {
+		counter, err := cfg.Meter.Int64Counter(
+			"desirelines.io/ratelimit/rejected",
+			metric.WithDescription("Requests rejected by the rate limiter, by reason (over_limit|map_full) and limiter"),
+		)
+		if err != nil {
+			logger.Warn("Failed to create ratelimit.rejected counter; rejections won't be metered", "error", err)
+		} else {
+			l.rejected = counter
+		}
 	}
 
 	go l.cleanup(ctx, cfg.cleanupInterval())
 	return l
+}
+
+// recordRejected increments the rejection counter (a no-op when no Meter was
+// configured). reason is "over_limit" (the IP's token bucket is empty) or
+// "map_full" (the per-IP client map is at capacity).
+func (l *Limiter) recordRejected(ctx context.Context, reason string) {
+	if l.rejected == nil {
+		return
+	}
+	l.rejected.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("reason", reason),
+		attribute.String("limiter", l.name),
+	))
 }
 
 // Middleware returns chi-compatible middleware that rejects requests exceeding the rate limit.
@@ -110,11 +146,18 @@ func (l *Limiter) Middleware(next http.Handler) http.Handler {
 
 		limiter := l.getLimiter(ip)
 		if limiter == nil {
+			l.recordRejected(r.Context(), "map_full")
 			w.Header().Set("Retry-After", "60")
 			apierrors.WriteError(w, r, apierrors.ErrRateLimited, l.logger)
 			return
 		}
 
+		// Reserve()+Cancel()-on-reject is how we read Delay() (for the Retry-After
+		// header) while emulating Allow(). Per x/time/rate, Cancel() only fully
+		// restores the token if no other Reserve/Allow ran on this limiter since —
+		// so under same-IP concurrency the accounting is best-effort (marginally
+		// stricter than the configured rate). Accepted: we need Delay(), which
+		// Allow() doesn't expose.
 		reservation := limiter.Reserve()
 		delay := reservation.Delay()
 		if delay == 0 {
@@ -137,6 +180,7 @@ func (l *Limiter) Middleware(next http.Handler) http.Handler {
 		}
 
 		w.Header().Set("Retry-After", retryAfter)
+		l.recordRejected(r.Context(), "over_limit")
 		apierrors.WriteError(w, r, apierrors.ErrRateLimited, l.logger)
 	})
 }
@@ -150,7 +194,12 @@ func (l *Limiter) getLimiter(ip string) *rate.Limiter {
 	e, ok := l.clients[ip]
 	if !ok {
 		if len(l.clients) >= l.maxClients {
-			l.logger.Warn("Rate limiter client map full, rejecting new IP",
+			// Debug, not Warn: this fires once per request from every new IP while
+			// the map is full — i.e. it amplifies exactly during the IP-rotation
+			// flood the cap defends against. The alertable signal is the
+			// desirelines.io/ratelimit/rejected counter (reason="map_full"); the
+			// per-IP detail stays at Debug.
+			l.logger.Debug("Rate limiter client map full, rejecting new IP",
 				"ip", ip, "max_clients", l.maxClients)
 			return nil
 		}

--- a/packages/shared/ratelimit/ratelimit_test.go
+++ b/packages/shared/ratelimit/ratelimit_test.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/andy-esch/desirelines/packages/shared/apierrors"
 	"github.com/andy-esch/desirelines/packages/shared/gcplog"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 const testRemoteAddr = "1.2.3.4:1234"
 
 func newTestLimiter(ctx context.Context, rate float64, burst int) *Limiter {
-	return New(ctx, Config{
+	return New(ctx, &Config{
 		Rate:            rate,
 		Burst:           burst,
 		CleanupInterval: time.Hour, // effectively disabled for most tests
@@ -101,12 +104,86 @@ func TestOverLimit(t *testing.T) {
 	}
 }
 
+// rejectedCountsByReason collects the desirelines.io/ratelimit/rejected counter
+// and returns its datapoints keyed by the "reason" attribute.
+func rejectedCountsByReason(t *testing.T, reader sdkmetric.Reader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	counts := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "desirelines.io/ratelimit/rejected" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("metric %s: unexpected data type %T", m.Name, m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				reason, _ := dp.Attributes.Value(attribute.Key("reason"))
+				counts[reason.AsString()] += dp.Value
+			}
+		}
+	}
+	return counts
+}
+
+func TestRejectionCounter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	// Burst=1, MaxClients=1: the first IP fills the only map slot and consumes its
+	// single token; a second request from it is over_limit; a new IP is map_full.
+	l := New(ctx, &Config{
+		Rate:            0.001,
+		Burst:           1,
+		MaxClients:      1,
+		CleanupInterval: time.Hour,
+		TTL:             time.Hour,
+		Name:            "test",
+		Meter:           provider.Meter("test"),
+	}, gcplog.NewNoOpLogger())
+	handler := l.Middleware(okHandler())
+
+	send := func(remoteAddr string) int {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = remoteAddr
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := send("1.1.1.1:1"); code != http.StatusOK {
+		t.Fatalf("first request: got %d, want 200", code)
+	}
+	if code := send("1.1.1.1:2"); code != http.StatusTooManyRequests {
+		t.Fatalf("over-limit request: got %d, want 429", code)
+	}
+	if code := send("2.2.2.2:1"); code != http.StatusTooManyRequests {
+		t.Fatalf("map-full request: got %d, want 429", code)
+	}
+
+	counts := rejectedCountsByReason(t, reader)
+	if counts["over_limit"] < 1 {
+		t.Errorf("over_limit count = %d, want >= 1", counts["over_limit"])
+	}
+	if counts["map_full"] < 1 {
+		t.Errorf("map_full count = %d, want >= 1", counts["map_full"])
+	}
+}
+
 func TestSkipBypassesLimiting(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Rate ~0 so the bucket never refills; Skip exempts the "/tiles/" prefix.
-	l := New(ctx, Config{
+	l := New(ctx, &Config{
 		Rate:            0.001,
 		Burst:           1,
 		CleanupInterval: time.Hour,
@@ -207,7 +284,7 @@ func TestStaleCleanup(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	l := New(ctx, Config{
+	l := New(ctx, &Config{
 		Rate:            10,
 		Burst:           10,
 		CleanupInterval: time.Hour, // won't fire automatically
@@ -235,7 +312,7 @@ func TestStaleCleanup(t *testing.T) {
 func TestCleanupStopsOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	_ = New(ctx, Config{
+	_ = New(ctx, &Config{
 		Rate:            10,
 		Burst:           10,
 		CleanupInterval: time.Millisecond,
@@ -272,7 +349,7 @@ func TestMaxClients(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	l := New(ctx, Config{
+	l := New(ctx, &Config{
 		Rate:            10,
 		Burst:           10,
 		MaxClients:      2,


### PR DESCRIPTION
Converges two observability gaps into one metric. The per-IP limiter now emits a desirelines.io/ratelimit/rejected Int64Counter with reason (over_limit|map_full) and limiter (default|auth|tile|dispatcher) attributes, wired into all four limiters (apigateway x3 + dispatcher) so rate-limiting is alertable instead of invisible:
- over_limit: token-bucket 429s that short-circuit before the request logger + http/request.duration histogram (by design).
- map_full: the per-IP client map hitting MaxClients. The per-request WARN that amplified during an IP-rotation flood is dropped to Debug; the counter is the alertable signal.

Also exempts the dispatcher's /health + HEAD / probes from the limiter via Config.Skip (probes hit every ~60s and shouldn't consume tokens) and documents the Reserve()/Cancel() best-effort accounting at the call site.

Adds Config.Name + Config.Meter; New takes *Config (Config grew past gocritic's hugeParam threshold). Adds a counter test asserting both reasons increment.