### PR TITLE
fix(web): routes-map filter a11y — slider value text + focus retention

### DIFF
--- a/packages/web/src/components/GoalSummaryTable.tsx
+++ b/packages/web/src/components/GoalSummaryTable.tsx
@@ -114,6 +114,7 @@ const GoalSummaryTable: React.FC<GoalSummaryTableProps> = ({
       <div className="card-body">
         <div className="overflow-x-auto">
           <table className="table table-hover table-sm table-dark-transparent">
+            <caption className="sr-only">Goal achievability summary</caption>
             <thead>
               <tr>
                 <th style={{ width: "10px" }}></th>
@@ -160,6 +161,7 @@ const GoalSummaryTable: React.FC<GoalSummaryTableProps> = ({
                         <div
                           className="progress-bar progress-bar-neon"
                           role="progressbar"
+                          aria-label={`${goal.label || "Unnamed"} progress`}
                           style={{
                             width: `${Math.min(100, progress)}%`,
                             backgroundColor: goalColor,

--- a/packages/web/src/components/dashboard/ActivityCalendarHeatmap.tsx
+++ b/packages/web/src/components/dashboard/ActivityCalendarHeatmap.tsx
@@ -447,11 +447,16 @@ export default function ActivityCalendarHeatmap({
                   const dateStr = toLocalDateString(date);
                   const count = activityCounts[dateStr] || 0;
                   const color = getIntensityColor(count);
+                  // Color alone can't convey the count to AT; expose the same text the
+                  // hover `title` shows as an image label (the cell is a data point).
+                  const cellLabel = `${dateStr}: ${count} ${count === 1 ? "activity" : "activities"}`;
 
                   return (
                     <div
                       key={dateStr}
-                      title={`${dateStr}: ${count} ${count === 1 ? "activity" : "activities"}`}
+                      role="img"
+                      aria-label={cellLabel}
+                      title={cellLabel}
                       style={{
                         width: CELL_SIZE,
                         height: CELL_SIZE,

--- a/packages/web/src/components/routes/DistanceHistogramChart.test.tsx
+++ b/packages/web/src/components/routes/DistanceHistogramChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import DistanceHistogramChart from "./DistanceHistogramChart";
 import type { MapActivity } from "../../api/map";
 
@@ -48,5 +48,17 @@ describe("DistanceHistogramChart", () => {
   it("shows an empty hint when there are no activities", () => {
     render(<DistanceHistogramChart activities={[]} distanceUnit="miles" onSelectRange={vi.fn()} />);
     expect(screen.getByText(/no activities to summarize/i)).toBeInTheDocument();
+  });
+
+  it("provides an sr-only data table as a text alternative to the chart", () => {
+    render(
+      <DistanceHistogramChart
+        activities={[act({ activityId: 1, distanceMeters: 5_000 })]}
+        distanceUnit="miles"
+        onSelectRange={vi.fn()}
+      />
+    );
+    const table = screen.getByRole("table", { name: /activity count by distance/i });
+    expect(within(table).getByText("Activities")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/routes/DistanceHistogramChart.tsx
+++ b/packages/web/src/components/routes/DistanceHistogramChart.tsx
@@ -49,47 +49,69 @@ export default function DistanceHistogramChart({
       {data.length === 0 ? (
         <p className="text-xs text-slate-light">No activities to summarize.</p>
       ) : (
-        <div className="h-32">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: -18 }}>
-              <CartesianGrid stroke="var(--color-chart-grid)" vertical={false} />
-              <XAxis
-                dataKey="label"
-                tick={{ fontSize: 9, fill: "var(--color-chart-tick)" }}
-                axisLine={false}
-                tickLine={false}
-                interval="preserveStartEnd"
-                minTickGap={8}
-              />
-              <YAxis
-                width={28}
-                allowDecimals={false}
-                tick={{ fontSize: 9, fill: "var(--color-chart-tick)" }}
-                axisLine={false}
-                tickLine={false}
-              />
-              <Tooltip
-                cursor={{ fill: "rgba(120,120,120,0.15)" }}
-                contentStyle={TOOLTIP_STYLE}
-                formatter={(v) => [`${Number(v)} activities`, "Count"]}
-                labelFormatter={(l) => `${l}+ ${unit}`}
-              />
-              <Bar
-                dataKey="count"
-                fill="var(--color-accent-cyan)"
-                radius={[2, 2, 0, 0]}
-                cursor="pointer"
-                isAnimationActive={false}
-                onClick={(d) => {
-                  const bin = d as unknown as Record<string, unknown>;
-                  if (typeof bin.start === "number" && typeof bin.end === "number") {
-                    onSelectRange([bin.start, bin.end]);
-                  }
-                }}
-              />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
+        <>
+          <div className="h-32" aria-hidden="true">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: -18 }}>
+                <CartesianGrid stroke="var(--color-chart-grid)" vertical={false} />
+                <XAxis
+                  dataKey="label"
+                  tick={{ fontSize: 9, fill: "var(--color-chart-tick)" }}
+                  axisLine={false}
+                  tickLine={false}
+                  interval="preserveStartEnd"
+                  minTickGap={8}
+                />
+                <YAxis
+                  width={28}
+                  allowDecimals={false}
+                  tick={{ fontSize: 9, fill: "var(--color-chart-tick)" }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <Tooltip
+                  cursor={{ fill: "rgba(120,120,120,0.15)" }}
+                  contentStyle={TOOLTIP_STYLE}
+                  formatter={(v) => [`${Number(v)} activities`, "Count"]}
+                  labelFormatter={(l) => `${l}+ ${unit}`}
+                />
+                <Bar
+                  dataKey="count"
+                  fill="var(--color-accent-cyan)"
+                  radius={[2, 2, 0, 0]}
+                  cursor="pointer"
+                  isAnimationActive={false}
+                  onClick={(d) => {
+                    const bin = d as unknown as Record<string, unknown>;
+                    if (typeof bin.start === "number" && typeof bin.end === "number") {
+                      onSelectRange([bin.start, bin.end]);
+                    }
+                  }}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          {/* Text alternative for the visual-only chart (the SVG bars are aria-hidden).
+              Bin-filtering — which the bars do on click, with no keyboard path — is also
+              reachable via the keyboard-operable distance slider. */}
+          <table className="sr-only">
+            <caption>Activity count by distance ({unit})</caption>
+            <thead>
+              <tr>
+                <th>Min distance ({unit})</th>
+                <th>Activities</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((b) => (
+                <tr key={b.label}>
+                  <td>{b.label}+</td>
+                  <td>{b.count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
       )}
     </section>
   );

--- a/packages/web/src/components/routes/MapActivityList.test.tsx
+++ b/packages/web/src/components/routes/MapActivityList.test.tsx
@@ -26,6 +26,7 @@ function renderList(over: Partial<MapActivityListProps> = {}) {
       act_({ activityId: 2, name: "Evening Run", sport: "running" }),
     ],
     sportColors: { cycling: "rgb(0,255,255)", running: "rgb(255,0,255)" },
+    sportLabels: { cycling: "Cycling", running: "Running" },
     distanceUnit: "miles",
     selectedId: null,
     onSelect,
@@ -43,11 +44,25 @@ describe("MapActivityList", () => {
     expect(screen.getByText("Evening Run")).toBeInTheDocument();
   });
 
+  it("shows the sport name as text so sport isn't conveyed by color alone", () => {
+    renderList();
+    expect(screen.getByText(/Cycling/)).toBeInTheDocument();
+    expect(screen.getByText(/Running/)).toBeInTheDocument();
+  });
+
+  it("announces the selection's effect via a polite live region", () => {
+    renderList({ selectedId: 1 });
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent(/Selected Morning Ride/);
+  });
+
   it("renders nothing when there are no activities", () => {
     const { container } = render(
       <MapActivityList
         activities={[]}
         sportColors={{}}
+        sportLabels={{}}
         distanceUnit="miles"
         selectedId={null}
         onSelect={vi.fn()}

--- a/packages/web/src/components/routes/MapActivityList.tsx
+++ b/packages/web/src/components/routes/MapActivityList.tsx
@@ -14,6 +14,8 @@ export interface MapActivityListProps {
   activities: MapActivity[];
   /** App-category → NEON spectrum color (shared with the chips + map lines). */
   sportColors: Record<string, string>;
+  /** App-category → display name, shown as text so sport isn't conveyed by color alone. */
+  sportLabels: Record<string, string>;
   distanceUnit: DistanceUnit;
   /** Activity id selected on the map (highlights + scrolls its row into view). */
   selectedId: number | null;
@@ -38,6 +40,7 @@ function stravaUrl(activityId: number): string {
 export default function MapActivityList({
   activities,
   sportColors,
+  sportLabels,
   distanceUnit,
   selectedId,
   onSelect,
@@ -81,9 +84,17 @@ export default function MapActivityList({
 
   const start = safePage * PAGE_SIZE;
   const pageItems = activities.slice(start, start + PAGE_SIZE);
+  const selectedActivity =
+    selectedId != null ? activities.find((a) => a.activityId === selectedId) : undefined;
 
   return (
     <section className="px-4 py-3" aria-label="Activities">
+      {/* Announce the selection's effect for AT: selecting a route highlights it + opens a
+          map popup that isn't in the tab order, so the visual cue alone is invisible to
+          screen-reader / keyboard users. */}
+      <p className="sr-only" role="status" aria-live="polite">
+        {selectedActivity ? `Selected ${selectedActivity.name} — highlighted on the map` : ""}
+      </p>
       <div className="mb-2 flex items-center justify-between gap-2">
         <button
           type="button"
@@ -166,7 +177,8 @@ export default function MapActivityList({
                     </span>
                     <span className="block text-xs tabular-nums text-slate-light">
                       {formatActivityDate(a.startDateLocal)} ·{" "}
-                      {formatDistance(a.distanceMeters, distanceUnit)}
+                      {formatDistance(a.distanceMeters, distanceUnit)} ·{" "}
+                      {sportLabels[a.sport] ?? a.sport}
                     </span>
                   </span>
                 </button>

--- a/packages/web/src/components/routes/MapFilterControls.test.tsx
+++ b/packages/web/src/components/routes/MapFilterControls.test.tsx
@@ -164,6 +164,14 @@ describe("MapFilterControls", () => {
     expect(screen.getByText("0 mi")).toBeInTheDocument();
   });
 
+  it("gives the distance slider thumbs unit-aware aria value text", () => {
+    renderControls();
+    // Screen readers hear "0 mi"/"50 mi", not the raw meters (0 / 80,000).
+    const thumbs = screen.getAllByRole("slider");
+    expect(thumbs[0]).toHaveAttribute("aria-valuetext", "0 mi");
+    expect(thumbs[1]).toHaveAttribute("aria-valuetext", "50 mi");
+  });
+
   it("lists regions by name with activity counts and selects one", async () => {
     const user = userEvent.setup();
     const { onSelectRegion } = renderControls();

--- a/packages/web/src/components/routes/MapFilterControls.tsx
+++ b/packages/web/src/components/routes/MapFilterControls.tsx
@@ -337,6 +337,8 @@ export default function MapFilterControls({
           step={distanceStep}
           value={sliderDistance}
           disabled={disabled}
+          // Screen readers hear "50 mi" (unit-aware), not the raw meter value.
+          getAriaValueText={(_, v) => `${fmt(v)} ${unitLabel}`}
           // Live thumb only — cheap local state, no filter/URL write per tick.
           onValueChange={(vals) => {
             const next = vals as number[];

--- a/packages/web/src/components/routes/MapFilterDrawer.test.tsx
+++ b/packages/web/src/components/routes/MapFilterDrawer.test.tsx
@@ -112,6 +112,31 @@ describe("MapFilterDrawer", () => {
     expect(document.activeElement).toBe(screen.getByRole("region", { name: /activity filters/i }));
   });
 
+  it("moves focus into the panel on an explicit open (closed → open)", () => {
+    const props: MapFilterDrawerProps = {
+      open: false,
+      onOpenChange: vi.fn(),
+      totals: TOTALS,
+      totalCount: 300,
+      activeFilterCount: 0,
+      onReset: vi.fn(),
+      onShowAll: vi.fn(),
+      distanceUnit: "miles",
+      elevationUnit: "feet",
+      isDark: true,
+    };
+    const { rerender } = render(<MapFilterDrawer {...props} />);
+    rerender(<MapFilterDrawer {...props} open />);
+    expect(document.activeElement).toBe(screen.getByRole("region", { name: /activity filters/i }));
+  });
+
+  it("does not steal focus on the default-open mount", () => {
+    renderDrawer({ open: true });
+    expect(document.activeElement).not.toBe(
+      screen.getByRole("region", { name: /activity filters/i })
+    );
+  });
+
   it("surfaces a filter-count badge when filters are active", () => {
     renderDrawer({ activeFilterCount: 3 });
     expect(screen.getAllByText("3").length).toBeGreaterThan(0);

--- a/packages/web/src/components/routes/MapFilterDrawer.test.tsx
+++ b/packages/web/src/components/routes/MapFilterDrawer.test.tsx
@@ -103,6 +103,15 @@ describe("MapFilterDrawer", () => {
     expect(onReset).toHaveBeenCalledTimes(1);
   });
 
+  it("parks keyboard focus on the panel (not <body>) when a reset control unmounts", async () => {
+    const user = userEvent.setup();
+    renderDrawer({ activeFilterCount: 2 });
+    // The reset link disappears once filters clear; focus must land on the labelled
+    // region rather than falling back to document.body.
+    await user.click(screen.getByRole("button", { name: /reset filters/i }));
+    expect(document.activeElement).toBe(screen.getByRole("region", { name: /activity filters/i }));
+  });
+
   it("surfaces a filter-count badge when filters are active", () => {
     renderDrawer({ activeFilterCount: 3 });
     expect(screen.getAllByText("3").length).toBeGreaterThan(0);

--- a/packages/web/src/components/routes/MapFilterDrawer.tsx
+++ b/packages/web/src/components/routes/MapFilterDrawer.tsx
@@ -194,11 +194,12 @@ export default function MapFilterDrawer({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [open, onOpenChange, toggleButtonRef]);
 
-  // This is the APG *disclosure* pattern, not a modal dialog: focus is NOT moved
-  // into the panel on open (that would steal focus on the default-open mount and
-  // dump keyboard users onto the collapse button). The panel joins the natural tab
-  // order via `inert` toggling below. On collapse we only return focus to the
-  // toggle if focus was inside the panel, so closing it keeps the user oriented.
+  // APG *disclosure* pattern, not a modal dialog. On an EXPLICIT open (user toggled
+  // closed → open) we move focus into the panel so keyboard users land on the revealed
+  // content; on the default-open mount focus is left alone (open was already true → no
+  // transition), so we never steal focus on load. The panel joins the natural tab order
+  // via `inert` toggling below. On collapse we return focus to the toggle only if focus
+  // was inside the panel, so closing it keeps the user oriented.
   const prevOpen = useRef(open);
   useEffect(() => {
     if (open && !prevOpen.current) {

--- a/packages/web/src/components/routes/MapFilterDrawer.tsx
+++ b/packages/web/src/components/routes/MapFilterDrawer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useRef } from "react";
-import type { CSSProperties, ReactNode } from "react";
+import type { CSSProperties, ReactNode, RefObject } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 import { useDebouncedValue } from "../../hooks/useDebouncedValue";
@@ -59,6 +59,9 @@ export interface MapFilterDrawerProps {
   onRefresh?: () => void;
   /** A refresh is in flight — spins the refresh control. */
   isRefreshing?: boolean;
+  /** Ref to the collapsed-state Filters toggle, so a parent (the on-map "Show all"
+   *  banner) can return keyboard focus to it after clearing the filters. */
+  toggleRef?: RefObject<HTMLButtonElement | null>;
   /** Filter controls / charts / activity list slot in here (later steps). */
   children?: ReactNode;
 }
@@ -158,9 +161,13 @@ export default function MapFilterDrawer({
   error = null,
   onRefresh,
   isRefreshing = false,
+  toggleRef,
   children,
 }: MapFilterDrawerProps) {
-  const toggleButtonRef = useRef<HTMLButtonElement>(null);
+  const internalToggleRef = useRef<HTMLButtonElement>(null);
+  // Use the parent's ref when provided (so it can return focus to this toggle after the
+  // on-map "Show all" banner clears the filters); otherwise a private one.
+  const toggleButtonRef = toggleRef ?? internalToggleRef;
   const panelRef = useRef<HTMLElement>(null);
   const headingId = useId();
   // Neon-cyan chrome in dark; readable theme default in light (see NEON_CHROME).
@@ -185,7 +192,7 @@ export default function MapFilterDrawer({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, onOpenChange]);
+  }, [open, onOpenChange, toggleButtonRef]);
 
   // This is the APG *disclosure* pattern, not a modal dialog: focus is NOT moved
   // into the panel on open (that would steal focus on the default-open mount and
@@ -194,11 +201,17 @@ export default function MapFilterDrawer({
   // toggle if focus was inside the panel, so closing it keeps the user oriented.
   const prevOpen = useRef(open);
   useEffect(() => {
-    if (!open && prevOpen.current && panelRef.current?.contains(document.activeElement)) {
+    if (open && !prevOpen.current) {
+      // EXPLICIT open (user toggled closed → open): move focus into the panel so keyboard
+      // users land on the revealed content instead of the now-hidden toggle. This does NOT
+      // fire on the default-open mount (open was already true → no transition), preserving
+      // the APG-disclosure choice not to steal focus on load.
+      panelRef.current?.focus();
+    } else if (!open && prevOpen.current && panelRef.current?.contains(document.activeElement)) {
       toggleButtonRef.current?.focus();
     }
     prevOpen.current = open;
-  }, [open]);
+  }, [open, toggleButtonRef]);
 
   const distanceLabel = getDistanceLabel(distanceUnit);
   const stats = isLoading
@@ -243,6 +256,19 @@ export default function MapFilterDrawer({
   // Debounced so a slider drag doesn't flood the `aria-live` region with every
   // intermediate readout — announce only once the filtering settles.
   const announcedSummary = useDebouncedValue(liveSummary, 500);
+
+  // Keep keyboard focus in the drawer when a reset control unmounts on activation
+  // (activeFilterCount → 0, or zero-result → stats view) — otherwise focus falls to
+  // <body>. The panel region is always present + labelled ("Activity filters") while
+  // open, so it's a safe, orienting anchor.
+  const resetAndKeepFocus = () => {
+    onReset();
+    panelRef.current?.focus();
+  };
+  const showAllAndKeepFocus = () => {
+    onShowAll();
+    panelRef.current?.focus();
+  };
 
   return (
     <>
@@ -293,6 +319,9 @@ export default function MapFilterDrawer({
         id={DRAWER_ID}
         role="region"
         aria-labelledby={headingId}
+        // Programmatically focusable (not in the tab order) so a reset action can park
+        // focus on the region instead of dropping it to <body> (see resetAndKeepFocus).
+        tabIndex={-1}
         style={neonChrome}
         // `inert` (not `aria-hidden`) when closed: removes the offscreen panel from
         // BOTH the a11y tree and the focus/pointer order in one deterministic step,
@@ -379,11 +408,11 @@ export default function MapFilterDrawer({
                   this is the only way out of an empty current year. */}
               {isZeroResult && (
                 <div className="mt-3 flex flex-wrap gap-2">
-                  <Button variant="outline" size="sm" onClick={onShowAll}>
+                  <Button variant="outline" size="sm" onClick={showAllAndKeepFocus}>
                     Show all activities
                   </Button>
                   {activeFilterCount > 0 && (
-                    <Button variant="ghost" size="sm" onClick={onReset}>
+                    <Button variant="ghost" size="sm" onClick={resetAndKeepFocus}>
                       Reset to this year
                     </Button>
                   )}
@@ -421,7 +450,7 @@ export default function MapFilterDrawer({
               {activeFilterCount > 0 && (
                 <Button
                   variant="link"
-                  onClick={onReset}
+                  onClick={resetAndKeepFocus}
                   className="mt-3 h-auto p-0 text-xs text-accent-cyan"
                 >
                   Reset filters

--- a/packages/web/src/components/routes/MapTimeRangeFilter.test.tsx
+++ b/packages/web/src/components/routes/MapTimeRangeFilter.test.tsx
@@ -42,4 +42,11 @@ describe("MapTimeRangeFilter", () => {
     renderFilter();
     expect(screen.getAllByRole("slider")).toHaveLength(2);
   });
+
+  it("gives the date slider thumbs date aria value text (not day-offset ints)", () => {
+    renderFilter();
+    const thumbs = screen.getAllByRole("slider");
+    expect(thumbs[0]).toHaveAttribute("aria-valuetext", "2026-01-01");
+    expect(thumbs[1]).toHaveAttribute("aria-valuetext", "2026-06-22");
+  });
 });

--- a/packages/web/src/components/routes/MapTimeRangeFilter.tsx
+++ b/packages/web/src/components/routes/MapTimeRangeFilter.tsx
@@ -84,6 +84,8 @@ export default function MapTimeRangeFilter({
         step={1}
         value={sliderValue}
         disabled={disabled}
+        // Screen readers hear the date (e.g. "2026-06-22"), not the raw day-offset int.
+        getAriaValueText={(_, v) => dayToYmd(startDay + v)}
         // Live thumb only — no filter/URL write per tick.
         onValueChange={(vals) => {
           const next = vals as number[];

--- a/packages/web/src/components/routes/RouteMap.tsx
+++ b/packages/web/src/components/routes/RouteMap.tsx
@@ -179,6 +179,9 @@ export interface SelectedRoute {
   name: string;
   distanceMeters: number;
   date: string;
+  /** Display name of the activity's sport, shown in the popup so sport isn't
+   *  conveyed by the line color alone (resolved from the dataset by the page). */
+  sportLabel?: string;
   lng?: number;
   lat?: number;
 }
@@ -834,6 +837,12 @@ function RoutePopupCard({
         </button>
       </div>
       <dl className="mt-2 space-y-0.5 text-xs text-slate-light">
+        {selected.sportLabel && (
+          <div className="flex justify-between gap-4">
+            <dt>Sport</dt>
+            <dd className="text-body-text">{selected.sportLabel}</dd>
+          </div>
+        )}
         <div className="flex justify-between gap-4">
           <dt>Distance</dt>
           <dd className="tabular-nums text-body-text">{distance}</dd>

--- a/packages/web/src/components/routes/WeeklyVolumeChart.test.tsx
+++ b/packages/web/src/components/routes/WeeklyVolumeChart.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import WeeklyVolumeChart from "./WeeklyVolumeChart";
 import type { MapActivity } from "../../api/map";
@@ -49,5 +49,11 @@ describe("WeeklyVolumeChart", () => {
   it("shows an empty hint when there are no activities", () => {
     render(<WeeklyVolumeChart activities={[]} distanceUnit="miles" />);
     expect(screen.getByText(/no activities to summarize/i)).toBeInTheDocument();
+  });
+
+  it("provides an sr-only data table as a text alternative to the chart", () => {
+    render(<WeeklyVolumeChart activities={[act()]} distanceUnit="miles" />);
+    const table = screen.getByRole("table", { name: /weekly distance by week/i });
+    expect(within(table).getByText("Week of")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/routes/WeeklyVolumeChart.tsx
+++ b/packages/web/src/components/routes/WeeklyVolumeChart.tsx
@@ -67,41 +67,61 @@ export default function WeeklyVolumeChart({ activities, distanceUnit }: WeeklyVo
       {data.length === 0 ? (
         <p className="text-xs text-slate-light">No activities to summarize.</p>
       ) : (
-        <div className="h-36">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: -18 }}>
-              <CartesianGrid stroke="var(--color-chart-grid)" vertical={false} />
-              <XAxis
-                dataKey="week"
-                tick={{ fontSize: 9, fill: "var(--color-chart-tick)" }}
-                tickFormatter={(d) => formatActivityDate(String(d))}
-                axisLine={false}
-                tickLine={false}
-                interval="preserveStartEnd"
-                minTickGap={24}
-              />
-              <YAxis
-                width={40}
-                tick={{ fontSize: 9, fill: "var(--color-chart-tick)" }}
-                axisLine={false}
-                tickLine={false}
-                tickFormatter={(v: number) => String(Math.round(v))}
-              />
-              <Tooltip
-                cursor={{ fill: "rgba(120,120,120,0.15)" }}
-                contentStyle={TOOLTIP_STYLE}
-                formatter={(v) => [`${Math.round(Number(v))} ${unit}`, "Volume"]}
-                labelFormatter={(d) => `Week of ${formatActivityDate(String(d), { year: true })}`}
-              />
-              <Bar
-                dataKey="value"
-                fill="var(--color-accent-cyan)"
-                radius={[2, 2, 0, 0]}
-                isAnimationActive={false}
-              />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
+        <>
+          <div className="h-36" aria-hidden="true">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: -18 }}>
+                <CartesianGrid stroke="var(--color-chart-grid)" vertical={false} />
+                <XAxis
+                  dataKey="week"
+                  tick={{ fontSize: 9, fill: "var(--color-chart-tick)" }}
+                  tickFormatter={(d) => formatActivityDate(String(d))}
+                  axisLine={false}
+                  tickLine={false}
+                  interval="preserveStartEnd"
+                  minTickGap={24}
+                />
+                <YAxis
+                  width={40}
+                  tick={{ fontSize: 9, fill: "var(--color-chart-tick)" }}
+                  axisLine={false}
+                  tickLine={false}
+                  tickFormatter={(v: number) => String(Math.round(v))}
+                />
+                <Tooltip
+                  cursor={{ fill: "rgba(120,120,120,0.15)" }}
+                  contentStyle={TOOLTIP_STYLE}
+                  formatter={(v) => [`${Math.round(Number(v))} ${unit}`, "Volume"]}
+                  labelFormatter={(d) => `Week of ${formatActivityDate(String(d), { year: true })}`}
+                />
+                <Bar
+                  dataKey="value"
+                  fill="var(--color-accent-cyan)"
+                  radius={[2, 2, 0, 0]}
+                  isAnimationActive={false}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          {/* Text alternative for the visual-only chart (the SVG bars are aria-hidden). */}
+          <table className="sr-only">
+            <caption>Weekly {metric === "distance" ? "distance" : "time"} by week</caption>
+            <thead>
+              <tr>
+                <th>Week of</th>
+                <th>{metric === "distance" ? `Distance (${unit})` : "Time (hours)"}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((d) => (
+                <tr key={d.week}>
+                  <td>{formatActivityDate(d.week, { year: true })}</td>
+                  <td>{d.value.toLocaleString(undefined, { maximumFractionDigits: 1 })}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
       )}
     </section>
   );

--- a/packages/web/src/components/ui/slider.tsx
+++ b/packages/web/src/components/ui/slider.tsx
@@ -15,8 +15,13 @@ function Slider({
   defaultValue,
   min = 0,
   max = 100,
+  getAriaValueText,
   ...props
-}: StringClass<React.ComponentProps<typeof BaseSlider.Root>>) {
+}: StringClass<React.ComponentProps<typeof BaseSlider.Root>> & {
+  /** Localized per-thumb `aria-valuetext` for screen readers (e.g. "50 mi" or a date)
+   *  instead of the raw internal number. Forwarded to each thumb's input. */
+  getAriaValueText?: (formattedValue: string, value: number, index: number) => string;
+}) {
   // Render one thumb per value (controlled or uncontrolled); fall back to a single
   // thumb at `min` when neither is provided.
   const thumbValues = React.useMemo<number[]>(() => {
@@ -42,6 +47,7 @@ function Slider({
             <BaseSlider.Thumb
               key={i}
               index={i}
+              getAriaValueText={getAriaValueText}
               className={cn(
                 "size-4 rounded-full border border-primary bg-card shadow-sm outline-none",
                 "transition-colors focus-visible:ring-2 focus-visible:ring-ring/40",

--- a/packages/web/src/pages/RoutesPage.test.tsx
+++ b/packages/web/src/pages/RoutesPage.test.tsx
@@ -630,5 +630,31 @@ describe("RoutesPage", () => {
         restore();
       }
     });
+
+    it("returns focus to the Filters toggle after the on-map 'Show all' banner", async () => {
+      const restore = setViewport(true); // mobile → drawer collapsed; banner + toggle both visible
+      try {
+        mockUseMapDataset.mockReturnValue({
+          activities: [{ ...activity, activityId: 9, startDateLocal: "2020-05-01T08:00:00" }],
+          isLoading: false,
+          error: null,
+        });
+        await renderWithRouter(<RoutesPage />);
+        await screen.findByTestId("route-map");
+
+        const banner = await screen.findByText(/no activities match your filters/i);
+        const showAll = within(banner.closest("div") as HTMLElement).getByRole("button", {
+          name: /show all activities/i,
+        });
+        // The collapsed drawer's Filters toggle must be present to receive focus.
+        const filtersToggle = await findFiltersToggle();
+
+        fireEvent.click(showAll);
+        // Banner unmounts as results appear; focus lands on the toggle, not <body>.
+        expect(document.activeElement).toBe(filtersToggle);
+      } finally {
+        restore();
+      }
+    });
   });
 });

--- a/packages/web/src/pages/RoutesPage.tsx
+++ b/packages/web/src/pages/RoutesPage.tsx
@@ -282,10 +282,11 @@ export default function RoutesPage() {
       name: a.name,
       distanceMeters: a.distanceMeters,
       date: a.startDateLocal.slice(0, 10),
+      sportLabel: sportLabels[a.sport] ?? a.sport,
       ...center,
     });
     requestFit(bbox);
-  }, [focusId, getActivity, requestFit]);
+  }, [focusId, getActivity, requestFit, sportLabels]);
 
   // Leave focus: clear the popup + drop ONLY the ?activity= param — the filter params
   // stay in the URL (they aren't about the focused activity).
@@ -312,11 +313,28 @@ export default function RoutesPage() {
         name: a.name,
         distanceMeters: a.distanceMeters,
         date: a.startDateLocal.slice(0, 10),
+        sportLabel: sportLabels[a.sport] ?? a.sport,
         ...center,
       });
       requestFit(bbox);
     },
-    [requestFit]
+    [requestFit, sportLabels]
+  );
+
+  // A route selected on the map arrives without sport (the tile carries the raw Strava
+  // type, not our app category), so enrich it with the dataset's app-category sport
+  // label — the popup shows sport as text, not line-color only.
+  const onSelectRoute = useCallback(
+    (route: SelectedRoute | null) => {
+      if (route === null) {
+        setSelected(null);
+        return;
+      }
+      const sport = getActivity(route.id)?.sport;
+      const sportLabel = sport ? (sportLabels[sport] ?? sport) : route.sportLabel;
+      setSelected(sportLabel !== undefined ? { ...route, sportLabel } : route);
+    },
+    [getActivity, sportLabels]
   );
 
   // Region select → filter to that region + frame it (uses the region's name/bbox
@@ -440,7 +458,7 @@ export default function RoutesPage() {
               distanceUnit={distanceUnit}
               getActivity={getActivity}
               selected={selected}
-              onSelect={setSelected}
+              onSelect={onSelectRoute}
               fitTo={fitTo}
             />
           </Suspense>
@@ -489,6 +507,7 @@ export default function RoutesPage() {
                 <MapActivityList
                   activities={routeFilters.filteredActivities}
                   sportColors={sportColors}
+                  sportLabels={sportLabels}
                   distanceUnit={distanceUnit}
                   selectedId={selected?.id ?? null}
                   onSelect={onSelectFromList}

--- a/packages/web/src/pages/RoutesPage.tsx
+++ b/packages/web/src/pages/RoutesPage.tsx
@@ -132,6 +132,9 @@ export default function RoutesPage() {
   // first render, so the initial value is correct with no open-then-close flash.
   const isMobile = useIsMobile();
   const [drawerOpen, setDrawerOpen] = useState(() => !isMobile);
+  // Return focus to the Filters toggle after the on-map "Show all" recourse (which
+  // unmounts the banner) so keyboard focus doesn't fall to <body>.
+  const filtersToggleRef = useRef<HTMLButtonElement>(null);
   // Insights (charts) drawer — auto-hidden by default (open via its toggle).
   const [insightsOpen, setInsightsOpen] = useState(false);
 
@@ -448,6 +451,7 @@ export default function RoutesPage() {
           <Suspense fallback={null}>
             <MapFilterDrawer
               open={drawerOpen}
+              toggleRef={filtersToggleRef}
               onOpenChange={openFilters}
               hideToggle={isMobile && insightsOpen}
               totals={routeFilters.totals}
@@ -610,7 +614,10 @@ export default function RoutesPage() {
                   </p>
                   <button
                     type="button"
-                    onClick={routeFilters.showAll}
+                    onClick={() => {
+                      routeFilters.showAll();
+                      filtersToggleRef.current?.focus();
+                    }}
                     className="mt-2 text-sm font-medium text-accent-cyan hover:underline"
                   >
                     Show all activities


### PR DESCRIPTION
Sliders announced raw internals to screen readers and keyboard focus fell to <body> when a filter-reset control unmounted on activation.

- Slider thumbs now expose localized aria-valuetext (distance in mi/km, time range as dates) via a getAriaValueText prop threaded through the ui/slider wrapper to Base UI's Slider.Thumb.
- Reset controls keep focus in context: the drawer's Reset/Show-all park focus on the labelled panel region; the on-map "Show all" banner returns focus to the Filters toggle (via a RefObject the drawer accepts).
- Focus moves into the filter panel on an explicit open (closed→open), but not on the default-open mount (preserves the APG-disclosure choice).