### PR TITLE
fix(apigateway): run CORS + security headers before the global rate limiter

### DIFF
--- a/packages/apigateway/internal/server/router.go
+++ b/packages/apigateway/internal/server/router.go
@@ -105,10 +105,37 @@ func IsTileRequest(r *http.Request) bool {
 func NewRouter(cfg RouterConfig, public PublicRoutes, auth AuthenticatedRoutes, logger *slog.Logger) chi.Router {
 	r := chi.NewRouter()
 
-	// Essential middleware
+	// MIDDLEWARE ORDER CONTRACT. chi runs Use-registered middleware
+	// outermost-first, so anything registered *after* the limiter is skipped when
+	// the limiter rejects (it writes the 429 and returns without calling next).
+	// Three constraints pin this order:
+	//
+	//  1. CloudRunRealIP must precede the limiter — the limiter keys per-IP
+	//     buckets off r.RemoteAddr and would otherwise bucket every request from
+	//     Cloud Run's front end together.
+	//  2. SecurityHeaders + CORS must precede the limiter, so a global 429 carries
+	//     Access-Control-Allow-Origin and a browser can actually read it (and the
+	//     Retry-After the limiter computes). Registered after, the response is
+	//     opaque cross-origin and surfaces as a network error instead of a 429.
+	//     Neither depends on the client IP, so they sit safely between the two.
+	//     This matches the tile limiter (scoped inside /v1) and the auth limiter
+	//     (inside /auth), both of which already reject inside CORS coverage.
+	//  3. The logger/metrics + span-stamp middleware stay *inside* the limiter, so
+	//     a 429 short-circuits before them. Deliberate, and the same call the
+	//     dispatcher documents at its own r.Use(rateLimiter.Middleware): folding
+	//     fast rejects into http/request.duration would drag the latency
+	//     distribution toward zero exactly during a flood. Rejections are observable
+	//     via desirelines.io/ratelimit/rejected{reason,limiter} instead.
+	//
+	// Consequence of (2): CORSMiddleware short-circuits OPTIONS preflight, so
+	// preflights no longer consume rate-limit tokens. Intended — a preflight does
+	// no downstream work, and a rate-limited preflight fails opaquely and takes the
+	// real request down with it. Same behavior the tile/auth limiters already have.
 	r.Use(chiMiddleware.RequestID)
 	r.Use(gcplog.BridgeRequestID)
 	r.Use(gcplog.CloudRunRealIP)
+	r.Use(SecurityHeaders)
+	r.Use(CORSMiddleware(cfg.CORSHandler))
 	if cfg.RateLimiter != nil {
 		r.Use(cfg.RateLimiter.Middleware)
 	}
@@ -122,10 +149,6 @@ func NewRouter(cfg RouterConfig, public PublicRoutes, auth AuthenticatedRoutes, 
 	r.Use(otel.TraceIDResponseHeader)
 	r.Use(gcplog.HTTPRequestLoggerWithMetrics(logger, cfg.HTTPHistogram))
 	r.Use(chiMiddleware.Recoverer)
-
-	// Security and CORS headers for all routes
-	r.Use(SecurityHeaders)
-	r.Use(CORSMiddleware(cfg.CORSHandler))
 
 	// Root-level endpoints (health checks)
 	r.Get("/health", public.Health)

--- a/packages/apigateway/internal/server/server_test.go
+++ b/packages/apigateway/internal/server/server_test.go
@@ -517,3 +517,132 @@ func TestNewRouter_AuthRateLimiterScopedToAuth(t *testing.T) {
 		}
 	})
 }
+
+// TestGlobalRateLimit429CarriesCORSHeaders pins the middleware-order contract
+// documented at the top of NewRouter: SecurityHeaders + CORS must run OUTSIDE the
+// global rate limiter.
+//
+// Regression: the limiter was registered above CORS, and chi runs Use-registered
+// middleware outermost-first, so a global 429 (written by the limiter, which
+// returns without calling next) skipped CORSMiddleware entirely. The response had
+// no Access-Control-Allow-Origin, so a cross-origin browser couldn't read it — the
+// app saw an opaque network error instead of a 429 it could act on, and the
+// Retry-After the limiter computes was unreachable.
+func TestGlobalRateLimit429CarriesCORSHeaders(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	c, err := cors.NewHandler([]string{"https://example.com"}, logger, false)
+	if err != nil {
+		t.Fatalf("cors.NewHandler: %v", err)
+	}
+
+	// 1 req/s, burst 1 — the second request in quick succession is rejected.
+	globalLimiter := ratelimit.New(ctx, &ratelimit.Config{
+		Rate:            1,
+		Burst:           1,
+		CleanupInterval: time.Hour,
+		TTL:             time.Hour,
+	}, logger)
+
+	router := NewRouter(
+		RouterConfig{
+			CORSHandler:    c,
+			AuthMiddleware: &mockAuthMiddleware{},
+			RateLimiter:    globalLimiter,
+		},
+		PublicRoutes{
+			Health:      func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) },
+			Ready:       func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) },
+			SportConfig: func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) },
+		},
+		noopAuthRoutes(),
+		logger,
+	)
+
+	get := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/v1/sports/config", nil)
+		req.RemoteAddr = "203.0.113.10:1234"
+		req.Header.Set("Origin", "https://example.com")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// Burn the single token; this one is allowed and must carry CORS.
+	if first := get(); first.Code != http.StatusOK {
+		t.Fatalf("first request: status = %d, want 200", first.Code)
+	} else if got := first.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("first request: Access-Control-Allow-Origin = %q, want https://example.com", got)
+	}
+
+	// Second request is rejected by the limiter. The 429 is the whole point: it must
+	// still be readable cross-origin.
+	rejected := get()
+	if rejected.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request: status = %d, want 429 (limiter should reject)", rejected.Code)
+	}
+	if got := rejected.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Errorf("429 Access-Control-Allow-Origin = %q, want https://example.com — a 429 without CORS is unreadable to the browser", got)
+	}
+	if got := rejected.Header().Get("Retry-After"); got == "" {
+		t.Error("429 Retry-After is empty — the limiter computes it, so it must survive to the client")
+	}
+	// SecurityHeaders sits alongside CORS above the limiter; assert it too so a
+	// future reorder that drops one but not the other still fails.
+	if got := rejected.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("429 X-Content-Type-Options = %q, want nosniff", got)
+	}
+}
+
+// TestPreflightBypassesGlobalRateLimiter documents a deliberate consequence of the
+// ordering above: CORSMiddleware short-circuits OPTIONS, so preflights resolve
+// before the limiter and never consume a token. Intended — a preflight does no
+// downstream work, and a rate-limited preflight fails opaquely and takes the real
+// request with it. If this ever needs to change, the limiter must learn to emit
+// CORS headers itself rather than moving CORS back inside it.
+func TestPreflightBypassesGlobalRateLimiter(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	c, err := cors.NewHandler([]string{"https://example.com"}, logger, false)
+	if err != nil {
+		t.Fatalf("cors.NewHandler: %v", err)
+	}
+
+	// Burst 1: if preflights consumed tokens, the 2nd of these would 429.
+	globalLimiter := ratelimit.New(ctx, &ratelimit.Config{
+		Rate:            1,
+		Burst:           1,
+		CleanupInterval: time.Hour,
+		TTL:             time.Hour,
+	}, logger)
+
+	router := NewRouter(
+		RouterConfig{
+			CORSHandler:    c,
+			AuthMiddleware: &mockAuthMiddleware{},
+			RateLimiter:    globalLimiter,
+		},
+		PublicRoutes{
+			Health:      func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) },
+			Ready:       func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) },
+			SportConfig: func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) },
+		},
+		noopAuthRoutes(),
+		logger,
+	)
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodOptions, "/v1/sports/config", nil)
+		req.RemoteAddr = "203.0.113.20:1234"
+		req.Header.Set("Origin", "https://example.com")
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("preflight %d was rate limited (status 429); preflights must resolve in CORS before the limiter", i)
+		}
+	}
+}


### PR DESCRIPTION
The global limiter was registered above CORSMiddleware. chi runs Use-registered middleware outermost-first and the limiter returns without calling next, so a global 429 skipped CORS entirely — no Access-Control-Allow-Origin, which means a cross-origin browser can't read the response. The frontend saw an opaque network error instead of a 429, and the Retry-After the limiter computes was unreachable.

Move SecurityHeaders + CORSMiddleware above the limiter, keeping CloudRunRealIP first (the limiter keys per-IP buckets off the real client IP; CORS doesn't need it). This matches the tile and auth limiters, which already reject inside CORS coverage — the global limiter was the outlier.

Document the ordering as an explicit contract at the top of NewRouter, including why the logger/metrics middleware deliberately stays inside the limiter.

Consequence: CORSMiddleware short-circuits OPTIONS, so preflights no longer consume rate-limit tokens. Intended — a preflight does no downstream work, and a rate-limited preflight previously failed opaquely and took the real request with it. Pinned by test.