### PR TITLE
fix(web): separate "constrained" from "resettable" in routes filters; theme a11y

### DIFF
--- a/packages/web/src/components/layout/AccountDropdown.test.tsx
+++ b/packages/web/src/components/layout/AccountDropdown.test.tsx
@@ -71,7 +71,16 @@ describe("AccountDropdown", () => {
     );
 
     openMenu();
-    const items = screen.getAllByRole("menuitem");
+    // Enumerate the whole menuitem family in DOM order, not just role="menuitem":
+    // the theme picker's buttons are `menuitemradio` (single-select group) and sit
+    // between the plain items, so they're part of the arrow-key sequence the
+    // component navigates. Querying only "menuitem" would skip them and test a
+    // narrower path than the user walks.
+    const items = Array.from(
+      screen
+        .getByRole("menu")
+        .querySelectorAll<HTMLElement>('[role="menuitem"], [role="menuitemradio"]')
+    );
     expect(items.length).toBeGreaterThanOrEqual(3);
 
     const secondToLast = items.at(-2);
@@ -84,6 +93,33 @@ describe("AccountDropdown", () => {
     // Fixed: advances to the next (last) item. Buggy: would reset to items[0].
     expect(document.activeElement).toBe(last);
     expect(document.activeElement).not.toBe(items[0]);
+  });
+
+  it("exposes the active theme programmatically, not just visually", () => {
+    // The active theme was conveyed only by border/background colour, so a screen
+    // reader user couldn't tell which was selected. useTheme is mocked to "system".
+    const onSignIn = vi.fn().mockResolvedValue(undefined);
+    const onSignOut = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <AccountDropdown user={{ uid: "abc" } as never} onSignIn={onSignIn} onSignOut={onSignOut} />
+    );
+
+    openMenu();
+
+    const themeGroup = screen.getByRole("group", { name: /theme/i });
+    expect(themeGroup).toBeInTheDocument();
+
+    const radios = screen.getAllByRole("menuitemradio");
+    expect(radios).toHaveLength(3);
+
+    expect(screen.getByRole("menuitemradio", { name: /system theme/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    for (const name of [/light theme/i, /dark theme/i]) {
+      expect(screen.getByRole("menuitemradio", { name })).toHaveAttribute("aria-checked", "false");
+    }
   });
 
   it("closes the menu after a successful sign-out", async () => {

--- a/packages/web/src/components/layout/AccountDropdown.tsx
+++ b/packages/web/src/components/layout/AccountDropdown.tsx
@@ -284,7 +284,10 @@ export function AccountDropdown({
             >
               Theme
             </div>
-            <div className="flex gap-0.5">
+            {/* menuitemradio + aria-checked, not menuitem: these are a single-select
+                group, so the active theme must be exposed programmatically — the
+                border/background treatment below conveys it to sighted users only. */}
+            <div className="flex gap-0.5" role="group" aria-label="Theme">
               {[
                 { mode: "light" as const, icon: <SunIcon size={13} />, label: "Light" },
                 { mode: "dark" as const, icon: <MoonIcon size={13} />, label: "Dark" },
@@ -293,7 +296,8 @@ export function AccountDropdown({
                 <button
                   key={mode}
                   type="button"
-                  role="menuitem"
+                  role="menuitemradio"
+                  aria-checked={theme === mode}
                   onClick={() => setTheme(mode)}
                   title={label}
                   aria-label={`${label} theme`}

--- a/packages/web/src/components/routes/MapFilterDrawer.test.tsx
+++ b/packages/web/src/components/routes/MapFilterDrawer.test.tsx
@@ -28,6 +28,7 @@ function renderDrawer(over: Partial<MapFilterDrawerProps> = {}) {
     totals: TOTALS,
     totalCount: 300,
     activeFilterCount: 0,
+    canReset: false,
     onReset,
     onShowAll,
     distanceUnit: "miles",
@@ -96,16 +97,32 @@ describe("MapFilterDrawer", () => {
     expect(screen.queryByRole("button", { name: /reset filters/i })).not.toBeInTheDocument();
   });
 
+  it("hides the reset control when the filters are already the defaults", () => {
+    // A fresh load on multi-year data constrains the set (badge shows 1) but reset
+    // would restore the current-year default that is *already applied* — a no-op.
+    // Reset affordances gate on canReset, never on activeFilterCount.
+    renderDrawer({ activeFilterCount: 1, canReset: false });
+    expect(screen.getByText("1")).toBeInTheDocument(); // badge still shown
+    expect(screen.queryByRole("button", { name: /reset filters/i })).not.toBeInTheDocument();
+  });
+
+  it("shows the reset control when nothing is constrained but reset would still act", () => {
+    // The Show-all state: constrains nothing (no badge), yet reset would narrow
+    // back to this year, so the affordance is real.
+    renderDrawer({ activeFilterCount: 0, canReset: true });
+    expect(screen.getByRole("button", { name: /reset filters/i })).toBeInTheDocument();
+  });
+
   it("resets when the reset control is clicked", async () => {
     const user = userEvent.setup();
-    const { onReset } = renderDrawer({ activeFilterCount: 2 });
+    const { onReset } = renderDrawer({ activeFilterCount: 2, canReset: true });
     await user.click(screen.getByRole("button", { name: /reset filters/i }));
     expect(onReset).toHaveBeenCalledTimes(1);
   });
 
   it("parks keyboard focus on the panel (not <body>) when a reset control unmounts", async () => {
     const user = userEvent.setup();
-    renderDrawer({ activeFilterCount: 2 });
+    renderDrawer({ activeFilterCount: 2, canReset: true });
     // The reset link disappears once filters clear; focus must land on the labelled
     // region rather than falling back to document.body.
     await user.click(screen.getByRole("button", { name: /reset filters/i }));
@@ -119,6 +136,7 @@ describe("MapFilterDrawer", () => {
       totals: TOTALS,
       totalCount: 300,
       activeFilterCount: 0,
+      canReset: false,
       onReset: vi.fn(),
       onShowAll: vi.fn(),
       distanceUnit: "miles",

--- a/packages/web/src/components/routes/MapFilterDrawer.tsx
+++ b/packages/web/src/components/routes/MapFilterDrawer.tsx
@@ -41,8 +41,16 @@ export interface MapFilterDrawerProps {
   totals: ActivityTotals;
   /** Size of the full dataset, for the "of N" context line. */
   totalCount: number;
-  /** Number of active (non-default) filter dimensions; shown as a badge. */
+  /** Number of dimensions actually constraining the set; shown as a badge. */
   activeFilterCount: number;
+  /**
+   * Whether the filters differ from the defaults, i.e. whether `onReset` would
+   * change anything. Distinct from `activeFilterCount > 0`: a fresh load
+   * constrains (badge) but has nothing to reset, and Show-all constrains nothing
+   * (no badge) yet reset would still narrow back to this year. Gate reset
+   * affordances on this so they never render as no-ops.
+   */
+  canReset: boolean;
   /** Reset filters to the defaults (current year, all sports/regions). */
   onReset: () => void;
   /** Widen to all activities (full date range, no filters) — the zero-result recourse. */
@@ -152,6 +160,7 @@ export default function MapFilterDrawer({
   totals,
   totalCount,
   activeFilterCount,
+  canReset,
   onReset,
   onShowAll,
   distanceUnit,
@@ -259,7 +268,7 @@ export default function MapFilterDrawer({
   const announcedSummary = useDebouncedValue(liveSummary, 500);
 
   // Keep keyboard focus in the drawer when a reset control unmounts on activation
-  // (activeFilterCount → 0, or zero-result → stats view) — otherwise focus falls to
+  // (canReset → false, or zero-result → stats view) — otherwise focus falls to
   // <body>. The panel region is always present + labelled ("Activity filters") while
   // open, so it's a safe, orienting anchor.
   const resetAndKeepFocus = () => {
@@ -412,7 +421,7 @@ export default function MapFilterDrawer({
                   <Button variant="outline" size="sm" onClick={showAllAndKeepFocus}>
                     Show all activities
                   </Button>
-                  {activeFilterCount > 0 && (
+                  {canReset && (
                     <Button variant="ghost" size="sm" onClick={resetAndKeepFocus}>
                       Reset to this year
                     </Button>
@@ -448,7 +457,7 @@ export default function MapFilterDrawer({
                   <Stat label="Elevation" value={stats.elevation} />
                 </div>
               </div>
-              {activeFilterCount > 0 && (
+              {canReset && (
                 <Button
                   variant="link"
                   onClick={resetAndKeepFocus}

--- a/packages/web/src/hooks/useRouteFilters.test.tsx
+++ b/packages/web/src/hooks/useRouteFilters.test.tsx
@@ -48,6 +48,13 @@ function setup(activities = DATASET) {
   return renderHook(() => useRouteFilters(activities, { now: NOW }));
 }
 
+// Every activity inside the current year, so the default window spans the whole
+// date domain and therefore constrains nothing. Isolates "date is not active".
+const SINGLE_YEAR: MapActivity[] = [
+  act_({ activityId: 1, sport: "cycling", startDateLocal: "2026-05-01T08:00:00" }),
+  act_({ activityId: 2, sport: "running", startDateLocal: "2026-02-10T08:00:00" }),
+];
+
 describe("useRouteFilters", () => {
   it("defaults to the current year, all sports/regions, no distance constraint", () => {
     const { result } = setup();
@@ -55,6 +62,16 @@ describe("useRouteFilters", () => {
     expect(result.current.filters.sports).toEqual([]);
     expect(result.current.filters.regionId).toBeNull();
     expect(result.current.filters.distanceRange).toBeNull();
+    // DATASET spans back to 2025, so the current-year default genuinely excludes
+    // data — "active" is measured against the domain, so it counts. See the
+    // SINGLE_YEAR case below for the same default reading 0 when it excludes nothing.
+    expect(result.current.activeFilterCount).toBe(1);
+    expect(result.current.isFiltered).toBe(true);
+  });
+
+  it("reads 0 active filters on a fresh load when the default year IS the whole domain", () => {
+    const { result } = renderHook(() => useRouteFilters(SINGLE_YEAR, { now: NOW }));
+    expect(result.current.dateDomain).toEqual(["2026-02-10", "2026-06-22"]);
     expect(result.current.activeFilterCount).toBe(0);
     expect(result.current.isFiltered).toBe(false);
   });
@@ -75,13 +92,15 @@ describe("useRouteFilters", () => {
 
   it("toggleSport adds then removes a sport and bumps the active count", () => {
     const { result } = setup();
+    // Counts are 2/1 rather than 1/0 because DATASET's current-year default already
+    // constrains the date domain — the sport toggle is the delta being asserted.
     act(() => result.current.toggleSport("cycling"));
     expect(result.current.filters.sports).toEqual(["cycling"]);
     expect(result.current.filteredIds).toEqual([1]); // only the 2026 cycling ride
-    expect(result.current.activeFilterCount).toBe(1);
+    expect(result.current.activeFilterCount).toBe(2); // sport + date
     act(() => result.current.toggleSport("cycling"));
     expect(result.current.filters.sports).toEqual([]);
-    expect(result.current.activeFilterCount).toBe(0);
+    expect(result.current.activeFilterCount).toBe(1); // date only
   });
 
   it("selectYear sets the date window and counts as an active filter", () => {
@@ -96,7 +115,14 @@ describe("useRouteFilters", () => {
     const { result } = setup();
     act(() => result.current.setDistanceRange([20_000, 100_000]));
     expect(result.current.filteredIds).toEqual([1]); // running (10k) drops out
-    expect(result.current.activeFilterCount).toBe(1);
+    expect(result.current.activeFilterCount).toBe(2); // distance + DATASET's default date
+  });
+
+  it("a distance slider parked at the full domain is not an active filter", () => {
+    const { result } = renderHook(() => useRouteFilters(SINGLE_YEAR, { now: NOW }));
+    const [lo, hi] = result.current.distanceDomain;
+    act(() => result.current.setDistanceRange([lo, hi]));
+    expect(result.current.activeFilterCount).toBe(0);
   });
 
   it("exposes a null mapFilter for an empty dataset, an id-set filter otherwise", () => {
@@ -120,6 +146,55 @@ describe("useRouteFilters", () => {
     expect(result.current.filteredIds).toEqual([1, 2, 3]);
   });
 
+  it("showAll leaves zero active filters — the un-filter action must not look filtered", () => {
+    const { result } = setup();
+    act(() => result.current.toggleSport("cycling"));
+    act(() => result.current.showAll());
+    // showAll widens date to the full domain, which excludes nothing. Previously the
+    // date branch compared against the default current-year range, so this reported a
+    // phantom active filter (and a Reset affordance) for a view that filters nothing.
+    expect(result.current.filteredIds).toEqual([1, 2, 3]);
+    expect(result.current.activeFilterCount).toBe(0);
+    expect(result.current.isFiltered).toBe(false);
+  });
+
+  it("canReset tracks 'reset would change something', not 'the view is constrained'", () => {
+    const { result } = setup();
+    // Fresh load: the current-year default constrains DATASET's 2025 data (count 1)
+    // but IS the default, so reset is a no-op. This pairing is the whole reason
+    // canReset exists separately — gating a Reset affordance on activeFilterCount
+    // would render a button that does nothing.
+    expect(result.current.activeFilterCount).toBe(1);
+    expect(result.current.canReset).toBe(false);
+
+    // showAll: constrains nothing (count 0) yet reset would narrow back to this
+    // year — the exact inverse.
+    act(() => result.current.showAll());
+    expect(result.current.activeFilterCount).toBe(0);
+    expect(result.current.canReset).toBe(true);
+
+    // Back to defaults → nothing to reset again.
+    act(() => result.current.reset());
+    expect(result.current.canReset).toBe(false);
+  });
+
+  it("canReset flips for any non-default dimension", () => {
+    const { result } = setup();
+    act(() => result.current.toggleSport("cycling"));
+    expect(result.current.canReset).toBe(true);
+    act(() => result.current.toggleSport("cycling"));
+    expect(result.current.canReset).toBe(false);
+
+    act(() => result.current.setRegionId(20));
+    expect(result.current.canReset).toBe(true);
+    act(() => result.current.setRegionId(null));
+    expect(result.current.canReset).toBe(false);
+
+    // distanceRange defaults to null, so any range at all is non-default.
+    act(() => result.current.setDistanceRange([0, 80_000]));
+    expect(result.current.canReset).toBe(true);
+  });
+
   it("reset restores every dimension to the defaults", () => {
     const { result } = setup();
     act(() => {
@@ -129,7 +204,9 @@ describe("useRouteFilters", () => {
     });
     expect(result.current.activeFilterCount).toBeGreaterThan(0);
     act(() => result.current.reset());
-    expect(result.current.activeFilterCount).toBe(0);
+    // reset restores the current-year default, which still constrains DATASET's
+    // 2025 data — hence 1, not 0. Use showAll() for a genuinely unfiltered view.
+    expect(result.current.activeFilterCount).toBe(1);
     expect(result.current.filters).toEqual({
       sports: [],
       distanceRange: null,

--- a/packages/web/src/hooks/useRouteFilters.ts
+++ b/packages/web/src/hooks/useRouteFilters.ts
@@ -5,6 +5,7 @@ import {
   type RouteFilterState,
   type ActivityTotals,
   defaultRouteFilters,
+  differsFromDefaults,
   filterMapActivities,
   summarizeMapActivities,
   activityDistanceDomain,
@@ -34,8 +35,15 @@ export interface UseRouteFiltersResult {
   dateDomain: [string, string];
   /** How many filter dimensions are constraining the set (drives the badge). */
   activeFilterCount: number;
-  /** Whether any filter deviates from the defaults. */
+  /** Shorthand for `activeFilterCount > 0` — whether the view is constrained. */
   isFiltered: boolean;
+  /**
+   * Whether `reset()` would change anything, i.e. the filters differ from the
+   * defaults. NOT interchangeable with `isFiltered` — the two disagree in both
+   * directions (a fresh load is constrained but not resettable; Show-all is
+   * resettable but not constrained). Gate reset affordances on this.
+   */
+  canReset: boolean;
   /** Replace sports (app categories); `[]` = all sports. */
   setSports: (sports: string[]) => void;
   /** Add/remove a single sport from the selection. */
@@ -187,12 +195,18 @@ export function useRouteFilters(
   );
   const totals = useMemo(() => summarizeMapActivities(filteredActivities), [filteredActivities]);
 
-  // A dimension is "active" when it actually constrains the set. Date is compared
-  // against the default current-year range (so the badge stays 0 on a fresh load);
-  // distance against the full data domain (a slider parked at [0, max] is *not* a
-  // constraint, mirroring the date treatment — not merely `distanceRange !== null`).
+  // A dimension is "active" when it actually constrains the set — i.e. when it
+  // narrows the data *domain*. Every dimension is measured that way, date included:
+  // a slider parked at [0, max] or a window spanning the full date domain excludes
+  // nothing, so neither counts.
+  //
+  // Date was previously measured against the default current-year range so the badge
+  // read 0 on a fresh load. That broke the invariant above: `showAll()` sets the date
+  // window to the full domain, which for multi-year data is != this Jan 1, so the
+  // un-filter action reported 1 active filter and offered a Reset for a view that
+  // excludes nothing. Domain-relative is the honest reading — on multi-year data a
+  // fresh current-year load genuinely IS constrained, and now says so.
   const activeFilterCount = useMemo(() => {
-    const [defStart, defEnd] = yearRange(now.getFullYear(), now);
     let count = 0;
     if (filters.sports.length > 0) count += 1;
     if (
@@ -202,9 +216,20 @@ export function useRouteFilters(
       count += 1;
     }
     if (filters.regionId !== null) count += 1;
-    if (filters.dateRange[0] !== defStart || filters.dateRange[1] !== defEnd) count += 1;
+    if (filters.dateRange[0] > dateDomain[0] || filters.dateRange[1] < dateDomain[1]) count += 1;
     return count;
-  }, [filters, now, distanceDomain]);
+  }, [filters, distanceDomain, dateDomain]);
+
+  // Whether reset() would change anything. Deliberately NOT the same question as
+  // activeFilterCount — the two disagree at both ends:
+  //
+  //   fresh load    → constrains (count 1, badge shown) but reset is a no-op (false)
+  //   after showAll → constrains nothing (count 0, no badge) but reset would narrow
+  //                   back to this year, so it's a real action (true)
+  //
+  // Gate reset affordances on this; gate badges/"filtered" copy on the count.
+  // Conflating them is what produced the phantom Reset this hook used to show.
+  const canReset = useMemo(() => differsFromDefaults(filters, now), [filters, now]);
 
   return {
     filters,
@@ -216,6 +241,7 @@ export function useRouteFilters(
     dateDomain,
     activeFilterCount,
     isFiltered: activeFilterCount > 0,
+    canReset,
     setSports,
     toggleSport,
     setDistanceRange,

--- a/packages/web/src/pages/RoutesPage.tsx
+++ b/packages/web/src/pages/RoutesPage.tsx
@@ -475,6 +475,7 @@ export default function RoutesPage() {
               totals={routeFilters.totals}
               totalCount={activities.length}
               activeFilterCount={routeFilters.activeFilterCount}
+              canReset={routeFilters.canReset}
               onReset={routeFilters.reset}
               onShowAll={routeFilters.showAll}
               distanceUnit={distanceUnit}

--- a/packages/web/src/utils/activityFilterSearch.ts
+++ b/packages/web/src/utils/activityFilterSearch.ts
@@ -96,7 +96,13 @@ export function searchToFilters(search: ActivityFilterSearch, now: Date): RouteF
   };
 }
 
-/** Serialize `RouteFilterState` → URL search, omitting anything at its default. */
+/**
+ * Serialize `RouteFilterState` → URL search, omitting anything at its default.
+ *
+ * The omit-if-default predicate below mirrors `differsFromDefaults` in
+ * routeFilters.ts field-for-field (this yields `{}` exactly when that returns
+ * false). Adding a filter dimension means updating both.
+ */
 export function filtersToSearch(filters: RouteFilterState, now: Date): ActivityFilterSearch {
   const def = defaultRouteFilters(now);
   const out: ActivityFilterSearch = {};

--- a/packages/web/src/utils/routeFilters.ts
+++ b/packages/web/src/utils/routeFilters.ts
@@ -57,6 +57,32 @@ export function mapPresetSports(visibleSports: string[], presentSports: string[]
   return visibleSports.filter((s) => presentSet.has(s));
 }
 
+/**
+ * Whether `filters` differs from `defaultRouteFilters(now)` — i.e. whether a
+ * reset would actually change something.
+ *
+ * Deliberately distinct from "is the view constrained" (see `activeFilterCount`
+ * in useRouteFilters, which measures against the data *domain*). The two disagree
+ * in both directions: a fresh current-year load on multi-year data constrains the
+ * set but is the default, and Show-all constrains nothing but is not the default.
+ * Reset affordances gate on this; badges gate on the count.
+ *
+ * NOTE: `filtersToSearch` in activityFilterSearch.ts encodes the same
+ * default-relative predicate field-by-field (it omits anything at its default, so
+ * it yields `{}` exactly when this returns false). Adding a filter dimension means
+ * updating both — keep them in step.
+ */
+export function differsFromDefaults(filters: RouteFilterState, now: Date = new Date()): boolean {
+  const def = defaultRouteFilters(now);
+  return (
+    filters.sports.length > 0 ||
+    filters.distanceRange !== null ||
+    filters.regionId !== null ||
+    filters.dateRange[0] !== def.dateRange[0] ||
+    filters.dateRange[1] !== def.dateRange[1]
+  );
+}
+
 /** Default filters: current year, all sports/regions, no distance constraint. */
 export function defaultRouteFilters(now: Date = new Date()): RouteFilterState {
   return {


### PR DESCRIPTION
activeFilterCount's contract is "a dimension is active when it actually constrains the set". Distance honored that by comparing against the data domain; date compared against the default current-year range. showAll() sets the date window to the full domain, which for multi-year data isn't Jan 1 — so the un-filter action reported an active filter and offered a Reset for a view that excludes nothing.

Measure date against the domain like every other dimension. Behavior change: on multi-year data a fresh current-year load now reports 1 active filter rather than 0 — the honest reading, since the default window genuinely excludes prior years.

That alone would relocate the bug rather than fix it: a fresh load would then offer a Reset that restores the already-applied default. The affordance and the badge are asking different questions, so add canReset (differs-from-defaults) next to activeFilterCount (constrains-the-set) and gate reset controls on it. The two disagree in both directions by design.

Extract differsFromDefaults into routeFilters.ts — filtersToSearch already encoded the same predicate field-by-field, and both must move together when a filter dimension is added.

Also: the theme picker used role="menuitem" and conveyed selection only via border/background colour, so screen-reader users couldn't tell which theme was active. Use role="menuitemradio" + aria-checked inside a labelled group.