### PR TITLE
perf(dispatcher): cache allowlist + token Firestore lookups on the webhook path

### DIFF
--- a/packages/dispatcher/adapters/cache/token_store.go
+++ b/packages/dispatcher/adapters/cache/token_store.go
@@ -1,0 +1,159 @@
+// Package cache provides caching decorators for the dispatcher's outbound ports.
+//
+// These sit on the synchronous webhook path — the work that must finish before
+// the dispatcher ACKs Strava (which expects a response within ~2s) — where a
+// Firestore round-trip is tens of milliseconds of pure serial latency.
+package cache
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/andy-esch/desirelines/packages/dispatcher/ports"
+	"github.com/andy-esch/desirelines/packages/shared/stravatoken"
+	"github.com/andy-esch/desirelines/packages/shared/ttlcache"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// DefaultTokenCacheMaxEntries bounds memory. Keyed by athlete ID, so cardinality
+// is the user count. A ceiling, not a tuning knob.
+const DefaultTokenCacheMaxEntries = 10_000
+
+// TokenStore decorates a ports.TokenStore with a bounded TTL cache, removing the
+// Firestore GetTokens round-trip (~42ms) from the webhook hot path.
+//
+// Tokens are sensitive, rotated data, so this caches on invalidation rather than
+// on hope: every write path drops the entry, whatever its outcome. The cache is
+// never the source of truth for a write — WriteTokensIfUnmodified's optimistic
+// concurrency still runs against Firestore, so a stale cached LastRefreshed
+// produces a conflict (which invalidates and re-reads), never a lost update.
+//
+// The TTL (config.DefaultTokenCacheTTL when unset) is a backstop, not the primary
+// consistency mechanism: local mutations invalidate directly, and the Strava
+// client invalidates on a rejected refresh. The one case none of those covers is a
+// write to the same Firestore doc by a DIFFERENT process — the apigateway's OAuth
+// callback on re-auth, which this in-process cache cannot see — and the TTL bounds
+// how long such a write can be shadowed.
+//
+// NOTE (concurrency): the read-through-then-Put is race-free ONLY because the
+// dispatcher runs one request at a time — max_instance_count = 1 AND
+// max_instance_request_concurrency = 1 in terraform/.../cloud_run.tf. With
+// concurrent requests, a read-through Put can land after a concurrent mutation's
+// invalidate and re-cache a stale value for a full TTL. Raising either knob
+// REQUIRES a per-key generation check in the read-through first. Documented at both
+// ends; see cloud_run.tf.
+type TokenStore struct {
+	inner  ports.TokenStore
+	cache  *ttlcache.Cache[int64, stravatoken.Data]
+	logger *slog.Logger
+}
+
+// Errors from the inner store are returned VERBATIM, never wrapped. Callers match
+// sentinels on them (ports.ErrTokenNotFound → orphan/ack-200,
+// ports.ErrTokenConflict → re-read the winner) and the strava client wraps them
+// with real context at its own call sites. A "cached token store:" layer would add
+// no information and would sit in the middle of every token error message.
+//
+// Compile-time checks.
+var (
+	_ ports.TokenStore       = (*TokenStore)(nil)
+	_ ports.TokenInvalidator = (*TokenStore)(nil)
+)
+
+// NewTokenStore wraps inner with a TTL cache.
+//
+// ttl <= 0 yields a DISABLED cache (every read passes through to inner), matching
+// ttlcache's own semantics — it is NOT rewritten to a default. The 5m default for
+// an *unset* config value belongs at the config layer, which alone can tell "unset"
+// (→ default) from an explicit "0" (→ disable). Rewriting 0→default here is what
+// made the documented kill switch silently a no-op. maxEntries <= 0 still takes
+// the package default (a cap, not a behavior toggle).
+func NewTokenStore(inner ports.TokenStore, ttl time.Duration, maxEntries int, logger *slog.Logger) *TokenStore {
+	if maxEntries <= 0 {
+		maxEntries = DefaultTokenCacheMaxEntries
+	}
+	return &TokenStore{
+		inner:  inner,
+		cache:  ttlcache.New[int64, stravatoken.Data](ttlcache.Config{TTL: ttl, MaxEntries: maxEntries}),
+		logger: logger,
+	}
+}
+
+// GetTokens returns cached tokens when fresh, otherwise reads through.
+//
+// The cache stores stravatoken.Data by VALUE and hands out a pointer to a fresh
+// copy. Data is flat (no reference fields), so this is a full copy — a caller
+// mutating the returned struct cannot corrupt the cached entry. Returning the
+// cached pointer directly would make every caller a co-owner of cache state.
+//
+// Errors are never cached: a Firestore blip must not become a TTL-long outage.
+func (s *TokenStore) GetTokens(ctx context.Context, athleteID int64) (*stravatoken.Data, error) {
+	span := trace.SpanFromContext(ctx)
+
+	if cached, ok := s.cache.Get(athleteID); ok {
+		stampCache(span, "strava_tokens", true)
+		out := cached // copy out of the cache
+		return &out, nil
+	}
+
+	tokens, err := s.inner.GetTokens(ctx, athleteID)
+	stampCache(span, "strava_tokens", false)
+	if err != nil {
+		//nolint:wrapcheck // Transparent decorator — see the note on the type.
+		return nil, err
+	}
+	if tokens != nil {
+		s.cache.Put(athleteID, *tokens) // copy into the cache
+	}
+	return tokens, nil
+}
+
+// WriteTokensIfUnmodified delegates and drops the cached entry, whatever happens.
+//
+// Invalidating unconditionally (rather than only on success) is what makes the
+// cache safe on every branch:
+//
+//   - success — the tokens we hold are now stale by definition.
+//   - ErrTokenConflict — another writer won. The caller's recovery is to re-read
+//     the winner's tokens; that read MUST bypass the cache or it would get the
+//     value that just lost, and could conflict forever. Dropping the entry here
+//     turns that re-read into a guaranteed miss.
+//   - ErrTokenNotFound — the tokens were deleted mid-refresh (deauth race).
+//   - transient failure — the write may or may not have landed. Unknown state is
+//     a reason to forget, not to keep.
+func (s *TokenStore) WriteTokensIfUnmodified(ctx context.Context, athleteID int64, tokens *stravatoken.Data, expectedLastRefreshed time.Time) error {
+	defer s.cache.Invalidate(athleteID)
+	//nolint:wrapcheck // Transparent decorator — see the note on the type.
+	return s.inner.WriteTokensIfUnmodified(ctx, athleteID, tokens, expectedLastRefreshed)
+}
+
+// DeleteTokens delegates and drops the cached entry, whatever happens. A deauth
+// that deleted the tokens but left them cached would keep the athlete's webhooks
+// succeeding against a dead grant for a full TTL.
+func (s *TokenStore) DeleteTokens(ctx context.Context, athleteID int64) error {
+	defer s.cache.Invalidate(athleteID)
+	//nolint:wrapcheck // Transparent decorator — see the note on the type.
+	return s.inner.DeleteTokens(ctx, athleteID)
+}
+
+// Invalidate drops the cached tokens for athleteID. Implements
+// ports.TokenInvalidator. The Strava client calls this when a refresh is rejected:
+// the cached tokens are known-bad, and Firestore may already hold fresh ones
+// (apigateway re-auth writes the same doc from another process, invisible to this
+// cache), so the next read must go through.
+func (s *TokenStore) Invalidate(athleteID int64) {
+	s.cache.Invalidate(athleteID)
+}
+
+// stampCache records the cache outcome on the active span, so a hit is visible in
+// the trace as an attribute and not merely as an absent Firestore child span.
+// Without it, "fast because cached" and "fast because Firestore was warm" look
+// identical, and the optimization becomes a blind spot.
+func stampCache(span trace.Span, name string, hit bool) {
+	span.SetAttributes(
+		attribute.Bool("cache.hit", hit),
+		attribute.String("cache.name", name),
+	)
+}

--- a/packages/dispatcher/adapters/cache/token_store.go
+++ b/packages/dispatcher/adapters/cache/token_store.go
@@ -7,7 +7,6 @@ package cache
 
 import (
 	"context"
-	"log/slog"
 	"time"
 
 	"github.com/andy-esch/desirelines/packages/dispatcher/ports"
@@ -45,9 +44,8 @@ const DefaultTokenCacheMaxEntries = 10_000
 // REQUIRES a per-key generation check in the read-through first. Documented at both
 // ends; see cloud_run.tf.
 type TokenStore struct {
-	inner  ports.TokenStore
-	cache  *ttlcache.Cache[int64, stravatoken.Data]
-	logger *slog.Logger
+	inner ports.TokenStore
+	cache *ttlcache.Cache[int64, stravatoken.Data]
 }
 
 // Errors from the inner store are returned VERBATIM, never wrapped. Callers match
@@ -70,14 +68,13 @@ var (
 // (→ default) from an explicit "0" (→ disable). Rewriting 0→default here is what
 // made the documented kill switch silently a no-op. maxEntries <= 0 still takes
 // the package default (a cap, not a behavior toggle).
-func NewTokenStore(inner ports.TokenStore, ttl time.Duration, maxEntries int, logger *slog.Logger) *TokenStore {
+func NewTokenStore(inner ports.TokenStore, ttl time.Duration, maxEntries int) *TokenStore {
 	if maxEntries <= 0 {
 		maxEntries = DefaultTokenCacheMaxEntries
 	}
 	return &TokenStore{
-		inner:  inner,
-		cache:  ttlcache.New[int64, stravatoken.Data](ttlcache.Config{TTL: ttl, MaxEntries: maxEntries}),
-		logger: logger,
+		inner: inner,
+		cache: ttlcache.New[int64, stravatoken.Data](ttlcache.Config{TTL: ttl, MaxEntries: maxEntries}),
 	}
 }
 

--- a/packages/dispatcher/adapters/cache/token_store_test.go
+++ b/packages/dispatcher/adapters/cache/token_store_test.go
@@ -3,7 +3,6 @@ package cache_test
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -105,7 +104,7 @@ func tokenData(access string) *stravatoken.Data {
 
 func newStore(t *testing.T, inner ports.TokenStore, ttl time.Duration) *cache.TokenStore {
 	t.Helper()
-	return cache.NewTokenStore(inner, ttl, 0, slog.Default())
+	return cache.NewTokenStore(inner, ttl, 0)
 }
 
 // The point of the whole exercise: a repeat read inside the TTL must not reach

--- a/packages/dispatcher/adapters/cache/token_store_test.go
+++ b/packages/dispatcher/adapters/cache/token_store_test.go
@@ -1,0 +1,456 @@
+package cache_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/andy-esch/desirelines/packages/dispatcher/adapters/cache"
+	"github.com/andy-esch/desirelines/packages/dispatcher/ports"
+	"github.com/andy-esch/desirelines/packages/shared/stravatoken"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// countingStore is a ports.TokenStore that records how many times each method was
+// called. The shared portstest.MockTokenStore doesn't count reads, and "did this
+// reach Firestore?" is the entire question these tests ask.
+type countingStore struct {
+	mu sync.Mutex
+
+	tokens   map[int64]*stravatoken.Data
+	getCalls int
+	getErr   error
+
+	writeCalls int
+	writeErr   error
+
+	deleteCalls int
+	deleteErr   error
+}
+
+func newCountingStore(d *stravatoken.Data) *countingStore {
+	s := &countingStore{tokens: map[int64]*stravatoken.Data{}}
+	if d != nil {
+		s.tokens[1] = d
+	}
+	return s
+}
+
+func (s *countingStore) GetTokens(_ context.Context, athleteID int64) (*stravatoken.Data, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getCalls++
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	t, ok := s.tokens[athleteID]
+	if !ok {
+		return nil, ports.ErrTokenNotFound
+	}
+	cp := *t
+	return &cp, nil
+}
+
+func (s *countingStore) WriteTokensIfUnmodified(_ context.Context, athleteID int64, tokens *stravatoken.Data, _ time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writeCalls++
+	if s.writeErr != nil {
+		return s.writeErr
+	}
+	cp := *tokens
+	s.tokens[athleteID] = &cp
+	return nil
+}
+
+func (s *countingStore) DeleteTokens(_ context.Context, athleteID int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleteCalls++
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	delete(s.tokens, athleteID)
+	return nil
+}
+
+func (s *countingStore) counts() (get, write, del int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.getCalls, s.writeCalls, s.deleteCalls
+}
+
+// setTokenDirectly writes to athlete 1 out of band, modeling a write by another
+// process (e.g. apigateway re-auth) that this cache cannot observe.
+func (s *countingStore) setTokenDirectly(d *stravatoken.Data) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tokens[1] = d
+}
+
+var _ ports.TokenStore = (*countingStore)(nil)
+
+func tokenData(access string) *stravatoken.Data {
+	return &stravatoken.Data{
+		AccessToken:   access,
+		RefreshToken:  "refresh",
+		ExpiresAt:     time.Now().Add(6 * time.Hour).Unix(),
+		LastRefreshed: time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func newStore(t *testing.T, inner ports.TokenStore, ttl time.Duration) *cache.TokenStore {
+	t.Helper()
+	return cache.NewTokenStore(inner, ttl, 0, slog.Default())
+}
+
+// The point of the whole exercise: a repeat read inside the TTL must not reach
+// Firestore.
+func TestSecondGetWithinTTLSkipsTheStore(t *testing.T) {
+	inner := newCountingStore(tokenData("access-1"))
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	first, err := s.GetTokens(ctx, 1)
+	if err != nil {
+		t.Fatalf("first GetTokens: %v", err)
+	}
+	second, err := s.GetTokens(ctx, 1)
+	if err != nil {
+		t.Fatalf("second GetTokens: %v", err)
+	}
+
+	if got, _, _ := inner.counts(); got != 1 {
+		t.Errorf("inner GetTokens called %d times, want 1 (second read should hit cache)", got)
+	}
+	if first.AccessToken != "access-1" || second.AccessToken != "access-1" {
+		t.Errorf("tokens = %q/%q, want access-1", first.AccessToken, second.AccessToken)
+	}
+}
+
+// A cached pointer handed straight back would make every caller a co-owner of
+// cache state; one mutation would silently poison every later reader.
+func TestGetReturnsACopyCallerCannotCorruptTheCache(t *testing.T) {
+	inner := newCountingStore(tokenData("access-1"))
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	first, err := s.GetTokens(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetTokens: %v", err)
+	}
+	first.AccessToken = "MUTATED BY CALLER"
+
+	second, err := s.GetTokens(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetTokens: %v", err)
+	}
+	if second.AccessToken != "access-1" {
+		t.Errorf("cached token = %q, want access-1 — caller mutation leaked into the cache", second.AccessToken)
+	}
+	if first == second {
+		t.Error("two reads returned the same pointer; each read must yield an independent copy")
+	}
+}
+
+// The acceptance criterion: a refresh must not be shadowed by a stale cached token.
+func TestWriteInvalidatesSoNextReadSeesNewTokens(t *testing.T) {
+	inner := newCountingStore(tokenData("old-access"))
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	if _, err := s.GetTokens(ctx, 1); err != nil { // populate the cache
+		t.Fatalf("GetTokens: %v", err)
+	}
+	if err := s.WriteTokensIfUnmodified(ctx, 1, tokenData("new-access"), time.Time{}); err != nil {
+		t.Fatalf("WriteTokensIfUnmodified: %v", err)
+	}
+
+	got, err := s.GetTokens(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetTokens after write: %v", err)
+	}
+	if got.AccessToken != "new-access" {
+		t.Errorf("token = %q, want new-access — the write did not invalidate the cache", got.AccessToken)
+	}
+}
+
+// The subtle one. On ErrTokenConflict the caller (strava client) re-reads to find
+// the winner's tokens. If that read were served from cache it would return the
+// value that just LOST the race, and the caller could conflict indefinitely.
+func TestWriteConflictInvalidatesSoTheConflictRereadFindsTheWinner(t *testing.T) {
+	inner := newCountingStore(tokenData("mine"))
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	if _, err := s.GetTokens(ctx, 1); err != nil { // cache "mine"
+		t.Fatalf("GetTokens: %v", err)
+	}
+
+	// Another writer wins the race: the store now holds their tokens and our
+	// optimistic write is rejected.
+	inner.mu.Lock()
+	inner.writeErr = ports.ErrTokenConflict
+	inner.mu.Unlock()
+	inner.setTokenDirectly(tokenData("winner"))
+
+	err := s.WriteTokensIfUnmodified(ctx, 1, tokenData("mine-refreshed"), time.Time{})
+	if !errors.Is(err, ports.ErrTokenConflict) {
+		t.Fatalf("WriteTokensIfUnmodified error = %v, want ErrTokenConflict", err)
+	}
+
+	got, err := s.GetTokens(ctx, 1)
+	if err != nil {
+		t.Fatalf("conflict re-read: %v", err)
+	}
+	if got.AccessToken != "winner" {
+		t.Errorf("conflict re-read returned %q, want winner — a cached loser was served", got.AccessToken)
+	}
+}
+
+// A failed write leaves the store in an unknown state. Unknown is a reason to
+// forget, not to keep serving what we happened to have.
+func TestTransientWriteFailureStillInvalidates(t *testing.T) {
+	inner := newCountingStore(tokenData("cached"))
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	if _, err := s.GetTokens(ctx, 1); err != nil {
+		t.Fatalf("GetTokens: %v", err)
+	}
+	getsBefore, _, _ := inner.counts()
+
+	inner.mu.Lock()
+	inner.writeErr = errors.New("firestore unavailable")
+	inner.mu.Unlock()
+	if err := s.WriteTokensIfUnmodified(ctx, 1, tokenData("attempted"), time.Time{}); err == nil {
+		t.Fatal("expected the write error to propagate")
+	}
+
+	if _, err := s.GetTokens(ctx, 1); err != nil {
+		t.Fatalf("GetTokens: %v", err)
+	}
+	if getsAfter, _, _ := inner.counts(); getsAfter != getsBefore+1 {
+		t.Error("read after a failed write was served from cache; unknown state must invalidate")
+	}
+}
+
+// A deauth that deletes tokens but leaves them cached would keep the athlete's
+// webhooks succeeding against a dead grant for a full TTL.
+func TestDeleteInvalidates(t *testing.T) {
+	inner := newCountingStore(tokenData("access-1"))
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	if _, err := s.GetTokens(ctx, 1); err != nil {
+		t.Fatalf("GetTokens: %v", err)
+	}
+	if err := s.DeleteTokens(ctx, 1); err != nil {
+		t.Fatalf("DeleteTokens: %v", err)
+	}
+
+	if _, err := s.GetTokens(ctx, 1); !errors.Is(err, ports.ErrTokenNotFound) {
+		t.Errorf("GetTokens after delete = %v, want ErrTokenNotFound — deleted tokens were served from cache", err)
+	}
+}
+
+// Caching a Firestore blip would turn it into a TTL-long outage for the athlete.
+func TestErrorsAreNotCached(t *testing.T) {
+	inner := newCountingStore(nil)
+	inner.getErr = errors.New("firestore unavailable")
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	if _, err := s.GetTokens(ctx, 1); err == nil {
+		t.Fatal("expected the read error to propagate")
+	}
+
+	// Firestore recovers.
+	inner.mu.Lock()
+	inner.getErr = nil
+	inner.mu.Unlock()
+	inner.setTokenDirectly(tokenData("recovered"))
+
+	got, err := s.GetTokens(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetTokens after recovery: %v", err)
+	}
+	if got.AccessToken != "recovered" {
+		t.Errorf("token = %q, want recovered", got.AccessToken)
+	}
+}
+
+// ErrTokenNotFound is an error, so it isn't cached either — a just-authorized
+// athlete must not be told "no tokens" for a whole TTL.
+func TestNotFoundIsNotCached(t *testing.T) {
+	inner := newCountingStore(nil)
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	if _, err := s.GetTokens(ctx, 1); !errors.Is(err, ports.ErrTokenNotFound) {
+		t.Fatalf("GetTokens = %v, want ErrTokenNotFound", err)
+	}
+
+	inner.setTokenDirectly(tokenData("just-authorized"))
+	got, err := s.GetTokens(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetTokens after authorization: %v", err)
+	}
+	if got.AccessToken != "just-authorized" {
+		t.Errorf("token = %q, want just-authorized — a NotFound was cached", got.AccessToken)
+	}
+}
+
+func TestEntryExpiresAfterTTL(t *testing.T) {
+	inner := newCountingStore(tokenData("access-1"))
+	s := newStore(t, inner, 10*time.Millisecond)
+	ctx := context.Background()
+
+	if _, err := s.GetTokens(ctx, 1); err != nil {
+		t.Fatalf("GetTokens: %v", err)
+	}
+	time.Sleep(25 * time.Millisecond)
+	if _, err := s.GetTokens(ctx, 1); err != nil {
+		t.Fatalf("GetTokens: %v", err)
+	}
+
+	if got, _, _ := inner.counts(); got != 2 {
+		t.Errorf("inner GetTokens called %d times, want 2 (entry should have expired)", got)
+	}
+}
+
+func TestWritesAndDeletesAlwaysReachTheInnerStore(t *testing.T) {
+	inner := newCountingStore(tokenData("access-1"))
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	// The cache must never absorb a mutation — it is a read cache only.
+	if err := s.WriteTokensIfUnmodified(ctx, 1, tokenData("x"), time.Time{}); err != nil {
+		t.Fatalf("WriteTokensIfUnmodified: %v", err)
+	}
+	if err := s.DeleteTokens(ctx, 1); err != nil {
+		t.Fatalf("DeleteTokens: %v", err)
+	}
+
+	_, writes, deletes := inner.counts()
+	if writes != 1 {
+		t.Errorf("inner writes = %d, want 1", writes)
+	}
+	if deletes != 1 {
+		t.Errorf("inner deletes = %d, want 1", deletes)
+	}
+}
+
+// cacheAttrs reads the cache.hit / cache.name attributes off a recorded span.
+func cacheAttrs(t *testing.T, span sdktrace.ReadOnlySpan) (hit, hasHit bool, name string) {
+	t.Helper()
+	for _, a := range span.Attributes() {
+		switch a.Key {
+		case "cache.hit":
+			hit, hasHit = a.Value.AsBool(), true
+		case "cache.name":
+			name = a.Value.AsString()
+		}
+	}
+	return hit, hasHit, name
+}
+
+// The acceptance criterion "cache hit/miss is visible in the trace". Without this
+// the optimization is a blind spot: a fast span could mean "cached" or "Firestore
+// was warm" and nothing distinguishes them.
+func TestCacheOutcomeIsStampedOnTheSpan(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	tracer := tp.Tracer("test")
+
+	inner := newCountingStore(tokenData("access-1"))
+	s := newStore(t, inner, time.Minute)
+
+	// Each call runs inside its own span, mirroring how the strava client wraps
+	// the token read in production.
+	for i := 0; i < 2; i++ {
+		ctx, span := tracer.Start(context.Background(), "test.get_tokens")
+		if _, err := s.GetTokens(ctx, 1); err != nil {
+			t.Fatalf("GetTokens: %v", err)
+		}
+		span.End()
+	}
+
+	ended := sr.Ended()
+	if len(ended) != 2 {
+		t.Fatalf("recorded %d spans, want 2", len(ended))
+	}
+
+	// First call: miss (read through to the store).
+	hit, hasHit, name := cacheAttrs(t, ended[0])
+	if !hasHit {
+		t.Fatal("first span carries no cache.hit attribute")
+	}
+	if hit {
+		t.Error("first span reports cache.hit=true; the cache was empty")
+	}
+	if name != "strava_tokens" {
+		t.Errorf("cache.name = %q, want strava_tokens", name)
+	}
+
+	// Second call: hit (no Firestore round-trip).
+	hit, hasHit, name = cacheAttrs(t, ended[1])
+	if !hasHit {
+		t.Fatal("second span carries no cache.hit attribute")
+	}
+	if !hit {
+		t.Error("second span reports cache.hit=false; the entry should have been cached")
+	}
+	if name != "strava_tokens" {
+		t.Errorf("cache.name = %q, want strava_tokens", name)
+	}
+}
+
+// F4: the Strava client invalidates on a rejected refresh via ports.TokenInvalidator.
+// After Invalidate, the next read must reach the store (which may hold fresh tokens
+// written out-of-process by the apigateway on re-auth).
+func TestInvalidateForcesReReadAfterRejectedRefresh(t *testing.T) {
+	inner := newCountingStore(tokenData("stale-from-cache"))
+	s := newStore(t, inner, time.Minute)
+	ctx := context.Background()
+
+	if _, err := s.GetTokens(ctx, 1); err != nil { // cache stale tokens
+		t.Fatalf("GetTokens: %v", err)
+	}
+
+	// Strava rejected the refresh; the client drops the entry via the interface.
+	var inv ports.TokenInvalidator = s
+	inv.Invalidate(1)
+
+	// Meanwhile apigateway re-auth wrote fresh tokens to Firestore.
+	inner.setTokenDirectly(tokenData("fresh-from-reauth"))
+
+	got, err := s.GetTokens(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetTokens after invalidate: %v", err)
+	}
+	if got.AccessToken != "fresh-from-reauth" {
+		t.Errorf("token = %q, want fresh-from-reauth — invalidate didn't force a re-read", got.AccessToken)
+	}
+}
+
+// F1/F7: ttl <= 0 disables the cache (passes through to ttlcache), it is NOT
+// rewritten to a default. The kill switch must actually kill.
+func TestZeroTTLDisablesTheCache(t *testing.T) {
+	inner := newCountingStore(tokenData("access-1"))
+	s := newStore(t, inner, 0)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if _, err := s.GetTokens(ctx, 1); err != nil {
+			t.Fatalf("GetTokens: %v", err)
+		}
+	}
+	if got, _, _ := inner.counts(); got != 3 {
+		t.Errorf("inner GetTokens called %d times, want 3 — ttl=0 must disable the cache", got)
+	}
+}

--- a/packages/dispatcher/adapters/http/handler.go
+++ b/packages/dispatcher/adapters/http/handler.go
@@ -625,6 +625,15 @@ func (h *Handler) handleAthleteEvent(ctx context.Context, w http.ResponseWriter,
 		)
 	}
 
+	// Drop any cached allowlist decision for this owner. The deletion service
+	// removes the allowlist doc out of process (a few seconds later), which this
+	// in-process cache can't observe; without this a straggler webhook in the
+	// window would read a stale allowed=true, find tokens gone, and trip the HIGH
+	// orphan alert. No-ops when the checker isn't a caching one.
+	if inv, ok := h.allowlist.(allowlist.Invalidator); ok {
+		inv.Invalidate(strconv.FormatInt(webhook.OwnerId, 10))
+	}
+
 	// Publish to the dedicated deauth topic. CONTRACT: the deauth signal is the *topic
 	// identity*, not the body — the published payload carries the athlete event (owner_id,
 	// aspect/object type) but no explicit `authorized:false` flag. Consumers act on receipt

--- a/packages/dispatcher/adapters/http/handler_test.go
+++ b/packages/dispatcher/adapters/http/handler_test.go
@@ -621,6 +621,37 @@ func TestHandler_AthleteDeauth(t *testing.T) {
 		}
 	})
 
+	t.Run("Deauth invalidates the allowlist cache for the owner", func(t *testing.T) {
+		// F2 wiring: without this, a straggler webhook after deauth would read a
+		// stale cached allowed=true, find tokens gone, and trip the HIGH orphan alert.
+		mockTokens := &portstest.MockTokenStore{}
+		mockAllow := portstest.NewAllowAllMockAllowlist()
+		tt := handleEventTestCase{
+			method:      "POST",
+			contentType: "application/json",
+			payload: webhookproto.StravaWebhookJSON{
+				AspectType:     "update",
+				EventTime:      testEventTime,
+				ObjectID:       testOwnerID,
+				ObjectType:     "athlete",
+				OwnerID:        testOwnerID,
+				SubscriptionID: testSubscriptionID,
+				Updates:        map[string]any{"authorized": "false"},
+			},
+			mockSubID:      testSubscriptionID,
+			mockTokenStore: mockTokens,
+			mockAllowlist:  mockAllow,
+			expectedStatus: http.StatusOK,
+			expectedBody:   "acknowledged",
+		}
+		runHandleEventTest(t, &tt)
+
+		want := strconv.FormatInt(testOwnerID, 10)
+		if len(mockAllow.InvalidatedWith) != 1 || mockAllow.InvalidatedWith[0] != want {
+			t.Errorf("expected allowlist Invalidate(%q) on deauth, got %v", want, mockAllow.InvalidatedWith)
+		}
+	})
+
 	t.Run("Deauth update with BOOLEAN authorized false deletes tokens (type-drift)", func(t *testing.T) {
 		mockTokens := &portstest.MockTokenStore{}
 		tt := handleEventTestCase{

--- a/packages/dispatcher/adapters/strava/client.go
+++ b/packages/dispatcher/adapters/strava/client.go
@@ -569,6 +569,14 @@ func (c *Client) refreshAndPersist(ctx context.Context, ownerID int64, tokens *s
 		// recommendation for the M1 rate-limit case).
 		if errors.Is(err, errRefreshTokenRejected) {
 			trace.SpanFromContext(ctx).SetAttributes(attribute.Bool("strava.refresh_rejected", true))
+			// The tokens we read are known-bad: Strava rejected the refresh token.
+			// If the store caches reads, drop the entry so the next attempt re-reads
+			// Firestore rather than re-serving the poison for a full TTL — the
+			// apigateway may already have written fresh tokens on re-auth (a write
+			// this in-process cache can't see). No-op on a non-caching store.
+			if inv, ok := c.tokenStore.(ports.TokenInvalidator); ok {
+				inv.Invalidate(ownerID)
+			}
 			return nil, err
 		}
 		lastErr = err

--- a/packages/dispatcher/cmd/dispatcher/main.go
+++ b/packages/dispatcher/cmd/dispatcher/main.go
@@ -18,12 +18,14 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
+	cacheadapter "github.com/andy-esch/desirelines/packages/dispatcher/adapters/cache"
 	envadapter "github.com/andy-esch/desirelines/packages/dispatcher/adapters/env"
 	firestoreadapter "github.com/andy-esch/desirelines/packages/dispatcher/adapters/firestore"
 	httpadapter "github.com/andy-esch/desirelines/packages/dispatcher/adapters/http"
 	"github.com/andy-esch/desirelines/packages/dispatcher/adapters/pubsub"
 	"github.com/andy-esch/desirelines/packages/dispatcher/adapters/strava"
 	"github.com/andy-esch/desirelines/packages/dispatcher/config"
+	"github.com/andy-esch/desirelines/packages/dispatcher/ports"
 	"github.com/andy-esch/desirelines/packages/shared/allowlist"
 	"github.com/andy-esch/desirelines/packages/shared/gcplog"
 	"github.com/andy-esch/desirelines/packages/shared/otel"
@@ -229,8 +231,31 @@ func initDependencies(cfg *config.Config, log *slog.Logger, meter metric.Meter, 
 	}
 	log.Info("Firestore client initialized", "database", cfg.FirestoreDatabase)
 
-	tokenStore := firestoreadapter.NewTokenStore(firestoreClient, log, firestoreHist, tracer)
-	allowChecker := allowlist.NewFirestoreChecker(firestoreClient, log)
+	// Both lookups below sit on the SYNCHRONOUS webhook path, strictly serial
+	// before Strava can be called (~45ms allowlist + ~42ms tokens), and both read
+	// data that changes rarely. Cache them to widen the margin against Strava's
+	// ~2s webhook timeout and cut Firestore read volume.
+	//
+	// Each cache can be disabled independently by setting its TTL env var to "0",
+	// so a suspected staleness bug is one redeploy away from being ruled out.
+	var tokenStore ports.TokenStore = firestoreadapter.NewTokenStore(firestoreClient, log, firestoreHist, tracer)
+	if cfg.TokenCacheTTL > 0 {
+		// IMPORTANT: one instance, shared by the Strava client (which reads and
+		// refreshes tokens) and the HTTP handler (which deletes them on deauth).
+		// Two wrappers would mean the handler's DeleteTokens invalidates a cache
+		// the Strava client never reads — a deauthed athlete's webhooks would keep
+		// succeeding against a dead grant until the TTL lapsed.
+		tokenStore = cacheadapter.NewTokenStore(tokenStore, cfg.TokenCacheTTL, 0, log)
+	}
+
+	var allowChecker allowlist.Checker = allowlist.NewFirestoreChecker(firestoreClient, log)
+	if cfg.AllowlistCacheTTL > 0 {
+		allowChecker = allowlist.NewCachingChecker(allowChecker, cfg.AllowlistCacheTTL, 0, log)
+	}
+	log.Info("Firestore lookup caches configured",
+		"allowlist_cache_ttl", cfg.AllowlistCacheTTL,
+		"token_cache_ttl", cfg.TokenCacheTTL,
+	)
 
 	secretProvider := envadapter.NewDefaultSecretCache(log)
 

--- a/packages/dispatcher/cmd/dispatcher/main.go
+++ b/packages/dispatcher/cmd/dispatcher/main.go
@@ -245,12 +245,12 @@ func initDependencies(cfg *config.Config, log *slog.Logger, meter metric.Meter, 
 		// Two wrappers would mean the handler's DeleteTokens invalidates a cache
 		// the Strava client never reads — a deauthed athlete's webhooks would keep
 		// succeeding against a dead grant until the TTL lapsed.
-		tokenStore = cacheadapter.NewTokenStore(tokenStore, cfg.TokenCacheTTL, 0, log)
+		tokenStore = cacheadapter.NewTokenStore(tokenStore, cfg.TokenCacheTTL, 0)
 	}
 
 	var allowChecker allowlist.Checker = allowlist.NewFirestoreChecker(firestoreClient, log)
 	if cfg.AllowlistCacheTTL > 0 {
-		allowChecker = allowlist.NewCachingChecker(allowChecker, cfg.AllowlistCacheTTL, 0, log)
+		allowChecker = allowlist.NewCachingChecker(allowChecker, cfg.AllowlistCacheTTL, 0)
 	}
 	log.Info("Firestore lookup caches configured",
 		"allowlist_cache_ttl", cfg.AllowlistCacheTTL,

--- a/packages/dispatcher/config/config.go
+++ b/packages/dispatcher/config/config.go
@@ -18,6 +18,18 @@ const (
 
 	// DefaultMaxRequestBodySize is the default maximum request body size (1MB)
 	DefaultMaxRequestBodySize int64 = 1 << 20
+
+	// DefaultAllowlistCacheTTL is applied when ALLOWLIST_CACHE_TTL is unset. Only
+	// positive decisions are cached and deauth invalidates them explicitly, so the
+	// TTL is a backstop bounding the false-orphan window if an invalidation is ever
+	// missed — not the primary consistency mechanism. Set the env var to "0" to
+	// disable the cache.
+	DefaultAllowlistCacheTTL = 5 * time.Minute
+
+	// DefaultTokenCacheTTL is applied when TOKEN_CACHE_TTL is unset. Bounds staleness
+	// against out-of-process token writes the in-process cache can't see (apigateway
+	// re-auth); local mutations invalidate directly. Set the env var to "0" to disable.
+	DefaultTokenCacheTTL = 5 * time.Minute
 )
 
 // Config holds non-secret configuration for the dispatcher.
@@ -32,6 +44,11 @@ type Config struct {
 	WriteTimeout           time.Duration
 	ReadHeaderTimeout      time.Duration
 	MaxRequestBodySize     int64
+	// AllowlistCacheTTL / TokenCacheTTL: 0 disables the respective cache, so a
+	// suspected staleness bug can be ruled out in prod by setting the env var to
+	// "0" and redeploying — no code change, no rollback.
+	AllowlistCacheTTL time.Duration
+	TokenCacheTTL     time.Duration
 }
 
 // LoadConfig loads non-secret configuration from environment variables.
@@ -79,6 +96,19 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 
+	// AllowZero, not parseDurationEnv: "0" is the documented kill switch (disable
+	// the cache), so it must parse to 0, not fail-closed the way a bad HTTP
+	// timeout should. Unset still takes the 5m default; negative is still rejected.
+	allowlistCacheTTL, err := parseDurationEnvAllowZero("ALLOWLIST_CACHE_TTL", DefaultAllowlistCacheTTL)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenCacheTTL, err := parseDurationEnvAllowZero("TOKEN_CACHE_TTL", DefaultTokenCacheTTL)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Config{
 		GCPProjectID:           gcpProjectID,
 		GCPPubSubTopicID:       gcpPubSubTopicID,
@@ -88,6 +118,8 @@ func LoadConfig() (*Config, error) {
 		WriteTimeout:           writeTimeout,
 		ReadHeaderTimeout:      readHeaderTimeout,
 		MaxRequestBodySize:     maxBodySize,
+		AllowlistCacheTTL:      allowlistCacheTTL,
+		TokenCacheTTL:          tokenCacheTTL,
 	}, nil
 }
 
@@ -104,6 +136,25 @@ func parseDurationEnv(key string, defaultValue time.Duration) (time.Duration, er
 	}
 	if d <= 0 {
 		return 0, fmt.Errorf("%s must be positive", key)
+	}
+	return d, nil
+}
+
+// parseDurationEnvAllowZero is parseDurationEnv for values where zero is a valid
+// "disable" signal rather than a misconfiguration: unset takes the default,
+// "0"/"0s" parses to 0 (caller treats it as disabled), and only a negative value
+// is an error. Used by the cache-TTL kill switches.
+func parseDurationEnvAllowZero(key string, defaultValue time.Duration) (time.Duration, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue, nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", key, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("%s must not be negative", key)
 	}
 	return d, nil
 }

--- a/packages/dispatcher/config/config_test.go
+++ b/packages/dispatcher/config/config_test.go
@@ -294,3 +294,55 @@ func TestParseLogLevel(t *testing.T) {
 		})
 	}
 }
+
+// The cache kill switch: TOKEN_CACHE_TTL / ALLOWLIST_CACHE_TTL = "0" must DISABLE
+// the cache (parse to 0), not fail LoadConfig. Regression guard — before the fix,
+// parseDurationEnv rejected 0 and setting the documented kill switch crashed the
+// dispatcher at boot instead of disabling the cache.
+func TestLoadConfig_CacheTTLKillSwitch(t *testing.T) {
+	setRequired := func(t *testing.T) {
+		t.Setenv("GCP_PROJECT_ID", "test-project")
+		t.Setenv("GCP_PUBSUB_TOPIC", "test-topic")
+		t.Setenv("GCP_PUBSUB_DEAUTH_TOPIC", "test-deauth-topic")
+		t.Setenv("FIRESTORE_DATABASE", "test-db")
+	}
+
+	t.Run("zero disables, does not error", func(t *testing.T) {
+		setRequired(t)
+		t.Setenv("TOKEN_CACHE_TTL", "0")
+		t.Setenv("ALLOWLIST_CACHE_TTL", "0")
+
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig with TTL=0 failed (kill switch must not crash boot): %v", err)
+		}
+		if cfg.TokenCacheTTL != 0 {
+			t.Errorf("TokenCacheTTL = %v, want 0", cfg.TokenCacheTTL)
+		}
+		if cfg.AllowlistCacheTTL != 0 {
+			t.Errorf("AllowlistCacheTTL = %v, want 0", cfg.AllowlistCacheTTL)
+		}
+	})
+
+	t.Run("unset takes the default", func(t *testing.T) {
+		setRequired(t)
+		unsetEnv(t, "TOKEN_CACHE_TTL")
+		unsetEnv(t, "ALLOWLIST_CACHE_TTL")
+
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+		if cfg.TokenCacheTTL != DefaultTokenCacheTTL {
+			t.Errorf("TokenCacheTTL = %v, want default %v", cfg.TokenCacheTTL, DefaultTokenCacheTTL)
+		}
+	})
+
+	t.Run("negative is rejected", func(t *testing.T) {
+		setRequired(t)
+		t.Setenv("TOKEN_CACHE_TTL", "-5m")
+		if _, err := LoadConfig(); err == nil {
+			t.Error("LoadConfig accepted a negative TTL; want an error")
+		}
+	})
+}

--- a/packages/dispatcher/ports/interfaces.go
+++ b/packages/dispatcher/ports/interfaces.go
@@ -53,6 +53,17 @@ type TokenStore interface {
 	DeleteTokens(ctx context.Context, athleteID int64) error
 }
 
+// TokenInvalidator is optionally implemented by a TokenStore that caches reads.
+// It lets a caller drop a cached entry it has just learned is stale — most
+// importantly the Strava client on a rejected refresh, where the poison would
+// otherwise be re-served until the cache TTL lapses, and where a fresh token may
+// already exist in Firestore (written out-of-process by the apigateway on
+// re-auth, which this in-process cache cannot see). A non-caching TokenStore does
+// not implement this, so callers type-assert and no-op when it's absent.
+type TokenInvalidator interface {
+	Invalidate(athleteID int64)
+}
+
 // StravaClient defines the outbound port for fetching activity data from the Strava API.
 type StravaClient interface {
 	// FetchActivity retrieves the raw JSON for a Strava activity by ID,

--- a/packages/dispatcher/ports/portstest/mocks.go
+++ b/packages/dispatcher/ports/portstest/mocks.go
@@ -187,6 +187,8 @@ type MockAllowlist struct {
 	Err error
 	// CalledWith records the athlete IDs IsAllowed was called with.
 	CalledWith []string
+	// InvalidatedWith records the athlete IDs Invalidate was called with.
+	InvalidatedWith []string
 }
 
 // NewAllowAllMockAllowlist returns a MockAllowlist preconfigured to allow
@@ -212,4 +214,12 @@ func (m *MockAllowlist) CalledCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.CalledWith)
+}
+
+// Invalidate records the athlete ID, letting MockAllowlist satisfy
+// allowlist.Invalidator so the deauth-invalidation wiring is testable.
+func (m *MockAllowlist) Invalidate(athleteID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.InvalidatedWith = append(m.InvalidatedWith, athleteID)
 }

--- a/packages/shared/allowlist/caching.go
+++ b/packages/shared/allowlist/caching.go
@@ -2,7 +2,6 @@ package allowlist
 
 import (
 	"context"
-	"log/slog"
 	"time"
 
 	"github.com/andy-esch/desirelines/packages/shared/ttlcache"
@@ -37,9 +36,8 @@ const DefaultCacheMaxEntries = 10_000
 // A "cached checker:" layer would add no information and would sit in the middle
 // of every allowlist error message.
 type CachingChecker struct {
-	inner  Checker
-	cache  *ttlcache.Cache[string, bool]
-	logger *slog.Logger
+	inner Checker
+	cache *ttlcache.Cache[string, bool]
 }
 
 // Invalidator is optionally implemented by a Checker that caches decisions. A
@@ -64,14 +62,13 @@ var (
 // unset-default belongs to the caller's config layer, which alone can distinguish
 // "unset" from an explicit "0" (disable). maxEntries <= 0 still takes the package
 // default (a memory cap, not a behavior toggle).
-func NewCachingChecker(inner Checker, ttl time.Duration, maxEntries int, logger *slog.Logger) *CachingChecker {
+func NewCachingChecker(inner Checker, ttl time.Duration, maxEntries int) *CachingChecker {
 	if maxEntries <= 0 {
 		maxEntries = DefaultCacheMaxEntries
 	}
 	return &CachingChecker{
-		inner:  inner,
-		cache:  ttlcache.New[string, bool](ttlcache.Config{TTL: ttl, MaxEntries: maxEntries}),
-		logger: logger,
+		inner: inner,
+		cache: ttlcache.New[string, bool](ttlcache.Config{TTL: ttl, MaxEntries: maxEntries}),
 	}
 }
 
@@ -101,18 +98,12 @@ func (c *CachingChecker) IsAllowed(ctx context.Context, athleteID string) (bool,
 
 	if _, ok := c.cache.Get(athleteID); ok {
 		// Only "allowed" is ever stored, so a hit is unconditionally true.
-		span.SetAttributes(
-			attribute.Bool("cache.hit", true),
-			attribute.String("cache.name", "allowlist"),
-		)
+		stampCacheHit(span, true)
 		return true, nil
 	}
 
 	allowed, err := c.inner.IsAllowed(ctx, athleteID)
-	span.SetAttributes(
-		attribute.Bool("cache.hit", false),
-		attribute.String("cache.name", "allowlist"),
-	)
+	stampCacheHit(span, false)
 	if err != nil {
 		//nolint:wrapcheck // Transparent decorator — see the note on the type.
 		return false, err
@@ -122,6 +113,15 @@ func (c *CachingChecker) IsAllowed(ctx context.Context, athleteID string) (bool,
 		c.cache.Put(athleteID, true)
 	}
 	return allowed, nil
+}
+
+// stampCacheHit records the cache outcome on the active span, so a hit is visible
+// in the trace as an attribute and not merely as an absent Firestore child span.
+func stampCacheHit(span trace.Span, hit bool) {
+	span.SetAttributes(
+		attribute.Bool("cache.hit", hit),
+		attribute.String("cache.name", "allowlist"),
+	)
 }
 
 // Invalidate drops the cached decision for athleteID, so the next IsAllowed

--- a/packages/shared/allowlist/caching.go
+++ b/packages/shared/allowlist/caching.go
@@ -1,0 +1,139 @@
+package allowlist
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/andy-esch/desirelines/packages/shared/ttlcache"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// DefaultCacheMaxEntries bounds the cache's memory. Keys are athlete IDs, so
+// cardinality is the user count — 1 today, and this survives four orders of
+// magnitude of growth before evicting. Sized as a ceiling against a key-explosion
+// bug (an unexpected id shape), not as a tuning knob.
+const DefaultCacheMaxEntries = 10_000
+
+// CachingChecker decorates a Checker with a bounded TTL cache.
+//
+// Intended for callers that check the same athlete repeatedly on a latency-
+// sensitive path — the dispatcher hits the allowlist on every inbound webhook,
+// where the Firestore round-trip is ~45ms of serial time before Strava can even
+// be called.
+//
+// NOT a blanket win. The apigateway deliberately does not use this: its only
+// IsAllowed call gates the OAuth callback, which runs once per sign-in. Caching
+// there would buy nothing measurable while widening the window in which a
+// just-revoked athlete could complete a sign-in. Cache where the read repeats,
+// not everywhere the interface appears.
+//
+// Only positive AND negative decisions are cached; errors never are (see IsAllowed).
+//
+// Errors from the inner Checker are returned VERBATIM, never wrapped. The Checker
+// contract makes callers branch on them (fail-closed → 500 → Strava retries), and
+// FirestoreChecker already wraps with real context ("firestore get allowlist/%s").
+// A "cached checker:" layer would add no information and would sit in the middle
+// of every allowlist error message.
+type CachingChecker struct {
+	inner  Checker
+	cache  *ttlcache.Cache[string, bool]
+	logger *slog.Logger
+}
+
+// Invalidator is optionally implemented by a Checker that caches decisions. A
+// caller that mutates allowlist state — the dispatcher, when it processes a
+// deauth — type-asserts to it and drops the entry, so the change is reflected
+// within Firestore-propagation latency instead of after a full TTL. A non-caching
+// Checker doesn't implement it, so the assertion no-ops.
+type Invalidator interface {
+	Invalidate(athleteID string)
+}
+
+// Compile-time checks.
+var (
+	_ Checker     = (*CachingChecker)(nil)
+	_ Invalidator = (*CachingChecker)(nil)
+)
+
+// NewCachingChecker wraps inner with a TTL cache.
+//
+// ttl <= 0 yields a DISABLED cache (every check passes through to inner), matching
+// ttlcache's own semantics — it is NOT rewritten to a default. Applying the
+// unset-default belongs to the caller's config layer, which alone can distinguish
+// "unset" from an explicit "0" (disable). maxEntries <= 0 still takes the package
+// default (a memory cap, not a behavior toggle).
+func NewCachingChecker(inner Checker, ttl time.Duration, maxEntries int, logger *slog.Logger) *CachingChecker {
+	if maxEntries <= 0 {
+		maxEntries = DefaultCacheMaxEntries
+	}
+	return &CachingChecker{
+		inner:  inner,
+		cache:  ttlcache.New[string, bool](ttlcache.Config{TTL: ttl, MaxEntries: maxEntries}),
+		logger: logger,
+	}
+}
+
+// IsAllowed returns a cached allow when fresh, otherwise delegates.
+//
+// Only POSITIVE decisions are cached. This is deliberate, and it is what keeps
+// the cache safe:
+//
+//   - "allowed" is the hot, stable fact — it's the single user on every webhook,
+//     and it changes only on deauth, which the dispatcher invalidates explicitly.
+//   - A cached "not allowed" would be a data-loss hazard: the handler 200-acks a
+//     rejected event (no Strava retry, stray is un-alerted), so a stale false
+//     silently drops a just-re-authorized athlete's activity for up to a TTL, with
+//     no signal. Re-auth is an apigateway write this cache can't see, so there's no
+//     clean invalidation for it — the right answer is to not cache the negative and
+//     fail fresh. Strays are rare (cross-env / post-deauth grants), so the Firestore
+//     read they now always pay is not on any hot path.
+//
+// Errors are never cached either: a fail-closed error becomes a 500 → Strava
+// retries, and a cached error would poison every retry in the window.
+//
+// Stamps cache.hit on the active span so a hit is visible in the trace both as
+// "span present, no Firestore child" and as an explicit attribute — the
+// optimization can't silently become a blind spot.
+func (c *CachingChecker) IsAllowed(ctx context.Context, athleteID string) (bool, error) {
+	span := trace.SpanFromContext(ctx)
+
+	if _, ok := c.cache.Get(athleteID); ok {
+		// Only "allowed" is ever stored, so a hit is unconditionally true.
+		span.SetAttributes(
+			attribute.Bool("cache.hit", true),
+			attribute.String("cache.name", "allowlist"),
+		)
+		return true, nil
+	}
+
+	allowed, err := c.inner.IsAllowed(ctx, athleteID)
+	span.SetAttributes(
+		attribute.Bool("cache.hit", false),
+		attribute.String("cache.name", "allowlist"),
+	)
+	if err != nil {
+		//nolint:wrapcheck // Transparent decorator — see the note on the type.
+		return false, err
+	}
+
+	if allowed {
+		c.cache.Put(athleteID, true)
+	}
+	return allowed, nil
+}
+
+// Invalidate drops the cached decision for athleteID, so the next IsAllowed
+// re-reads Firestore.
+//
+// This IS wired: the dispatcher calls it when it processes a deauth (which is
+// followed, out of process, by the deletion service removing the allowlist doc).
+// Without it a straggler webhook arriving after deauth would read a cached
+// allowed=true, find the tokens already deleted, and trip the HIGH
+// webhook_owner_check_orphan alert — turning the deliberately-quiet stray path
+// loud for up to a full TTL. Invalidating here keeps the false-orphan window at
+// the inherent Firestore-propagation latency, cache or no cache.
+func (c *CachingChecker) Invalidate(athleteID string) {
+	c.cache.Invalidate(athleteID)
+}

--- a/packages/shared/allowlist/caching_test.go
+++ b/packages/shared/allowlist/caching_test.go
@@ -3,7 +3,6 @@ package allowlist_test
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -45,7 +44,7 @@ var _ allowlist.Checker = (*countingChecker)(nil)
 
 func TestSecondCheckWithinTTLSkipsTheChecker(t *testing.T) {
 	inner := &countingChecker{allowed: true}
-	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10)
 	ctx := context.Background()
 
 	for i := 0; i < 3; i++ {
@@ -68,7 +67,7 @@ func TestSecondCheckWithinTTLSkipsTheChecker(t *testing.T) {
 // full TTL. Strays are rare, so failing fresh here costs nothing on any hot path.
 func TestNegativeDecisionsAreNotCached(t *testing.T) {
 	inner := &countingChecker{allowed: false}
-	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10)
 	ctx := context.Background()
 
 	for i := 0; i < 3; i++ {
@@ -89,7 +88,7 @@ func TestNegativeDecisionsAreNotCached(t *testing.T) {
 // consequence of not caching the earlier "not allowed" reads.
 func TestNewlyAddedAthleteIsNotRejectedByAStaleNegative(t *testing.T) {
 	inner := &countingChecker{allowed: false}
-	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10)
 	ctx := context.Background()
 
 	if allowed, err := c.IsAllowed(ctx, "123"); err != nil || allowed {
@@ -105,7 +104,7 @@ func TestNewlyAddedAthleteIsNotRejectedByAStaleNegative(t *testing.T) {
 // re-reads Firestore (where the deletion service has since removed the doc).
 func TestInvalidateAfterAllowedForcesReRead(t *testing.T) {
 	inner := &countingChecker{allowed: true}
-	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10)
 	ctx := context.Background()
 
 	if allowed, err := c.IsAllowed(ctx, "123"); err != nil || !allowed { // cache the allow
@@ -128,7 +127,7 @@ func TestInvalidateAfterAllowedForcesReRead(t *testing.T) {
 // every retry inside the window — the retries would never reach Firestore.
 func TestErrorsAreNotCached(t *testing.T) {
 	inner := &countingChecker{allowed: false, err: errors.New("firestore unavailable")}
-	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10)
 	ctx := context.Background()
 
 	if _, err := c.IsAllowed(ctx, "123"); err == nil {
@@ -150,7 +149,7 @@ func TestErrorsAreNotCached(t *testing.T) {
 
 func TestDecisionsAreKeyedPerAthlete(t *testing.T) {
 	inner := &countingChecker{allowed: true}
-	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10)
 	ctx := context.Background()
 
 	if _, err := c.IsAllowed(ctx, "111"); err != nil {
@@ -168,7 +167,7 @@ func TestDecisionsAreKeyedPerAthlete(t *testing.T) {
 
 func TestEntryExpiresAfterTTL(t *testing.T) {
 	inner := &countingChecker{allowed: true}
-	c := allowlist.NewCachingChecker(inner, 10*time.Millisecond, 10, slog.Default())
+	c := allowlist.NewCachingChecker(inner, 10*time.Millisecond, 10)
 	ctx := context.Background()
 
 	if _, err := c.IsAllowed(ctx, "123"); err != nil {
@@ -194,7 +193,7 @@ func TestEntryExpiresAfterTTL(t *testing.T) {
 // passes through — this is the kill switch, and it must actually kill.
 func TestZeroTTLDisablesTheCache(t *testing.T) {
 	inner := &countingChecker{allowed: true}
-	c := allowlist.NewCachingChecker(inner, 0, 0, slog.Default())
+	c := allowlist.NewCachingChecker(inner, 0, 0)
 	ctx := context.Background()
 
 	for i := 0; i < 3; i++ {

--- a/packages/shared/allowlist/caching_test.go
+++ b/packages/shared/allowlist/caching_test.go
@@ -1,0 +1,208 @@
+package allowlist_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/andy-esch/desirelines/packages/shared/allowlist"
+)
+
+// countingChecker records how many times the underlying check ran — "did this
+// reach Firestore?" is the whole question here.
+type countingChecker struct {
+	mu      sync.Mutex
+	calls   int
+	allowed bool
+	err     error
+}
+
+func (c *countingChecker) IsAllowed(_ context.Context, _ string) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	return c.allowed, c.err
+}
+
+func (c *countingChecker) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+// setAllowed changes the decision and clears any configured error — i.e. models
+// "the backend recovered and now says this".
+func (c *countingChecker) setAllowed(allowed bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.allowed, c.err = allowed, nil
+}
+
+var _ allowlist.Checker = (*countingChecker)(nil)
+
+func TestSecondCheckWithinTTLSkipsTheChecker(t *testing.T) {
+	inner := &countingChecker{allowed: true}
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		allowed, err := c.IsAllowed(ctx, "123")
+		if err != nil {
+			t.Fatalf("IsAllowed: %v", err)
+		}
+		if !allowed {
+			t.Fatal("IsAllowed = false, want true")
+		}
+	}
+	if got := inner.callCount(); got != 1 {
+		t.Errorf("inner called %d times, want 1 — repeat checks should hit the cache", got)
+	}
+}
+
+// Negative decisions are NOT cached — every "not allowed" re-reads Firestore.
+// A cached false is a data-loss hazard: the handler 200-acks a rejected event, so
+// a stale false would silently drop a just-re-authorized athlete's activity for a
+// full TTL. Strays are rare, so failing fresh here costs nothing on any hot path.
+func TestNegativeDecisionsAreNotCached(t *testing.T) {
+	inner := &countingChecker{allowed: false}
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		allowed, err := c.IsAllowed(ctx, "123")
+		if err != nil {
+			t.Fatalf("IsAllowed: %v", err)
+		}
+		if allowed {
+			t.Fatal("IsAllowed = true, want false")
+		}
+	}
+	if got := inner.callCount(); got != 3 {
+		t.Errorf("inner called %d times, want 3 — negatives must not be cached", got)
+	}
+}
+
+// A just-added athlete must take effect immediately, not after a TTL — a direct
+// consequence of not caching the earlier "not allowed" reads.
+func TestNewlyAddedAthleteIsNotRejectedByAStaleNegative(t *testing.T) {
+	inner := &countingChecker{allowed: false}
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	ctx := context.Background()
+
+	if allowed, err := c.IsAllowed(ctx, "123"); err != nil || allowed {
+		t.Fatalf("precondition: expected (false, nil), got (%v, %v)", allowed, err)
+	}
+	inner.setAllowed(true) // admin adds the athlete
+	if allowed, err := c.IsAllowed(ctx, "123"); err != nil || !allowed {
+		t.Errorf("IsAllowed = %v, %v; want true, nil — a stale negative was served", allowed, err)
+	}
+}
+
+// Deauth invalidation: after the dispatcher drops a cached allow, the next check
+// re-reads Firestore (where the deletion service has since removed the doc).
+func TestInvalidateAfterAllowedForcesReRead(t *testing.T) {
+	inner := &countingChecker{allowed: true}
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	ctx := context.Background()
+
+	if allowed, err := c.IsAllowed(ctx, "123"); err != nil || !allowed { // cache the allow
+		t.Fatalf("precondition: expected (true, nil), got (%v, %v)", allowed, err)
+	}
+	c.Invalidate("123")     // dispatcher processes deauth
+	inner.setAllowed(false) // deletion service removed the doc
+
+	allowed, err := c.IsAllowed(ctx, "123")
+	if err != nil {
+		t.Fatalf("IsAllowed: %v", err)
+	}
+	if allowed {
+		t.Error("served a cached allow after Invalidate; deauth must force a re-read")
+	}
+}
+
+// Callers fail CLOSED on an allowlist error (dispatcher returns 500 so Strava
+// retries). Caching an error would turn a blip into a TTL-long outage AND poison
+// every retry inside the window — the retries would never reach Firestore.
+func TestErrorsAreNotCached(t *testing.T) {
+	inner := &countingChecker{allowed: false, err: errors.New("firestore unavailable")}
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	ctx := context.Background()
+
+	if _, err := c.IsAllowed(ctx, "123"); err == nil {
+		t.Fatal("expected the error to propagate")
+	}
+
+	inner.setAllowed(true) // Firestore recovers
+	allowed, err := c.IsAllowed(ctx, "123")
+	if err != nil {
+		t.Fatalf("IsAllowed after recovery: %v", err)
+	}
+	if !allowed {
+		t.Error("IsAllowed = false; the retry was served a cached error instead of re-reading")
+	}
+	if got := inner.callCount(); got != 2 {
+		t.Errorf("inner called %d times, want 2", got)
+	}
+}
+
+func TestDecisionsAreKeyedPerAthlete(t *testing.T) {
+	inner := &countingChecker{allowed: true}
+	c := allowlist.NewCachingChecker(inner, time.Minute, 10, slog.Default())
+	ctx := context.Background()
+
+	if _, err := c.IsAllowed(ctx, "111"); err != nil {
+		t.Fatal(err)
+	}
+	inner.setAllowed(false)
+	allowed, err := c.IsAllowed(ctx, "222")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed {
+		t.Error("athlete 222 was served athlete 111's cached decision")
+	}
+}
+
+func TestEntryExpiresAfterTTL(t *testing.T) {
+	inner := &countingChecker{allowed: true}
+	c := allowlist.NewCachingChecker(inner, 10*time.Millisecond, 10, slog.Default())
+	ctx := context.Background()
+
+	if _, err := c.IsAllowed(ctx, "123"); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(25 * time.Millisecond)
+
+	// An athlete removed from the allowlist takes effect within one TTL.
+	inner.setAllowed(false)
+	allowed, err := c.IsAllowed(ctx, "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed {
+		t.Error("removal did not take effect after the TTL elapsed")
+	}
+	if got := inner.callCount(); got != 2 {
+		t.Errorf("inner called %d times, want 2", got)
+	}
+}
+
+// ttl <= 0 DISABLES the cache (it is not rewritten to a default). Every check
+// passes through — this is the kill switch, and it must actually kill.
+func TestZeroTTLDisablesTheCache(t *testing.T) {
+	inner := &countingChecker{allowed: true}
+	c := allowlist.NewCachingChecker(inner, 0, 0, slog.Default())
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.IsAllowed(ctx, "123"); err != nil {
+			t.Fatalf("IsAllowed: %v", err)
+		}
+	}
+	if got := inner.callCount(); got != 3 {
+		t.Errorf("inner called %d times, want 3 — ttl=0 must disable the cache, not default it", got)
+	}
+}

--- a/packages/shared/ttlcache/ttlcache.go
+++ b/packages/shared/ttlcache/ttlcache.go
@@ -1,0 +1,175 @@
+// Package ttlcache provides a small, bounded, TTL-expiring key/value cache.
+//
+// It exists to serve read-through caches in front of Firestore lookups that sit
+// on a synchronous request path — where the cost of a round-trip (tens of ms) is
+// paid on every request for data that changes rarely.
+//
+// Deliberately minimal:
+//
+//   - No background goroutine. Expiry is lazy (a stale entry reads as a miss) and
+//     eviction happens on insert. A cache keyed by athlete is bounded by the user
+//     count, so there is nothing to sweep between writes. Contrast
+//     shared/ratelimit, which is keyed by client IP — unbounded by nature, hence
+//     its cleanup loop.
+//   - No metrics or tracing. Callers know what a hit *means* in their domain and
+//     own the span/attribute vocabulary; a cache that stamps spans forces one
+//     opinion on every caller. Decorators do that instead.
+//   - No singleflight/stampede control. At the scale this serves (single-user
+//     today, per-athlete keys), concurrent misses for the same key are rare and
+//     the duplicate read is cheaper than the machinery.
+//
+// The zero value is not usable; construct with New.
+package ttlcache
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultMaxEntries is used when Config.MaxEntries is non-positive.
+const DefaultMaxEntries = 1024
+
+// Config configures a Cache.
+type Config struct {
+	// TTL is how long an entry stays fresh after being written. An entry older
+	// than this reads as a miss.
+	//
+	// Non-positive TTL disables the cache: every Get misses and Put is a no-op.
+	// A disabled cache is a valid, useful state — it lets a caller turn caching
+	// off from config without a nil check on every call site — so it is not an
+	// error.
+	TTL time.Duration
+
+	// MaxEntries bounds the map. On insert past the bound, expired entries are
+	// purged first; if the cache is still full, the entry nearest expiry is
+	// evicted to make room. This is a memory ceiling, not a tuning knob — size it
+	// above the expected key cardinality. Non-positive means DefaultMaxEntries.
+	MaxEntries int
+
+	// Now overrides the clock. nil means time.Now. Tests inject this to advance
+	// past a TTL without sleeping.
+	Now func() time.Time
+}
+
+type entry[V any] struct {
+	value     V
+	expiresAt time.Time
+}
+
+// Cache is a bounded, TTL-expiring map safe for concurrent use.
+type Cache[K comparable, V any] struct {
+	mu      sync.RWMutex
+	entries map[K]entry[V]
+	ttl     time.Duration
+	max     int
+	now     func() time.Time
+}
+
+// New creates a Cache. It cannot fail: a non-positive TTL yields a disabled
+// cache (all misses) and a non-positive MaxEntries takes DefaultMaxEntries. Both
+// are documented, safe behaviors rather than errors, so callers can wire this
+// from config without an error branch or a nil check.
+func New[K comparable, V any](cfg Config) *Cache[K, V] {
+	maxEntries := cfg.MaxEntries
+	if maxEntries <= 0 {
+		maxEntries = DefaultMaxEntries
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Cache[K, V]{
+		entries: make(map[K]entry[V]),
+		ttl:     cfg.TTL,
+		max:     maxEntries,
+		now:     now,
+	}
+}
+
+// enabled reports whether the cache stores anything. A non-positive TTL means it
+// is off; Get short-circuits to a miss and Put drops the write.
+func (c *Cache[K, V]) enabled() bool { return c.ttl > 0 }
+
+// Get returns the cached value for key. The bool is false on a miss OR on an
+// expired entry — callers cannot distinguish the two, and shouldn't need to.
+//
+// Expired entries are left in place rather than deleted, so this can take a read
+// lock. Purge happens on insert; the map stays bounded by MaxEntries regardless.
+func (c *Cache[K, V]) Get(key K) (V, bool) {
+	if !c.enabled() {
+		var zero V
+		return zero, false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	e, ok := c.entries[key]
+	if !ok || !c.now().Before(e.expiresAt) {
+		var zero V
+		return zero, false
+	}
+	return e.value, true
+}
+
+// Put stores value under key, replacing any existing entry and restarting its TTL.
+func (c *Cache[K, V]) Put(key K, value V) {
+	if !c.enabled() {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.entries[key]; !exists && len(c.entries) >= c.max {
+		c.evictLocked()
+	}
+	c.entries[key] = entry[V]{value: value, expiresAt: c.now().Add(c.ttl)}
+}
+
+// Invalidate drops key. Safe to call for a key that isn't cached.
+//
+// This is the correctness hook: a caller that mutates the underlying data must
+// invalidate, or the cache will serve a value it knows to be wrong.
+func (c *Cache[K, V]) Invalidate(key K) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
+}
+
+// Len reports the number of entries held, including expired-but-not-yet-purged
+// ones. Intended for tests and diagnostics, not for cache-hit accounting.
+func (c *Cache[K, V]) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
+// evictLocked makes room for one entry. Caller must hold the write lock.
+//
+// Purge expired first — that usually suffices and costs nothing in correctness.
+// Only if every entry is live do we evict the one nearest expiry, which is the
+// least-useful live entry to keep.
+func (c *Cache[K, V]) evictLocked() {
+	now := c.now()
+	for k, e := range c.entries {
+		if !now.Before(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+	if len(c.entries) < c.max {
+		return
+	}
+
+	var oldestKey K
+	var oldestAt time.Time
+	first := true
+	for k, e := range c.entries {
+		if first || e.expiresAt.Before(oldestAt) {
+			oldestKey, oldestAt, first = k, e.expiresAt, false
+		}
+	}
+	if !first {
+		delete(c.entries, oldestKey)
+	}
+}

--- a/packages/shared/ttlcache/ttlcache_test.go
+++ b/packages/shared/ttlcache/ttlcache_test.go
@@ -1,0 +1,209 @@
+package ttlcache_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/andy-esch/desirelines/packages/shared/ttlcache"
+)
+
+// fakeClock lets a test cross a TTL boundary without sleeping.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func newTestCache(clk *fakeClock, ttl time.Duration, maxEntries int) *ttlcache.Cache[string, int] {
+	return ttlcache.New[string, int](ttlcache.Config{TTL: ttl, MaxEntries: maxEntries, Now: clk.Now})
+}
+
+func TestGetMissOnUnknownKey(t *testing.T) {
+	c := newTestCache(newClock(), time.Minute, 10)
+	if _, ok := c.Get("nope"); ok {
+		t.Error("Get on an empty cache returned a hit")
+	}
+}
+
+func TestPutThenGetHits(t *testing.T) {
+	c := newTestCache(newClock(), time.Minute, 10)
+	c.Put("a", 42)
+	got, ok := c.Get("a")
+	if !ok {
+		t.Fatal("Get after Put missed")
+	}
+	if got != 42 {
+		t.Errorf("Get = %d, want 42", got)
+	}
+}
+
+func TestEntryExpiresAfterTTL(t *testing.T) {
+	clk := newClock()
+	c := newTestCache(clk, time.Minute, 10)
+	c.Put("a", 1)
+
+	// Just inside the window: still a hit.
+	clk.Advance(59 * time.Second)
+	if _, ok := c.Get("a"); !ok {
+		t.Error("entry expired before its TTL elapsed")
+	}
+
+	// Exactly at the boundary: expired. TTL is the max age, not a grace period.
+	clk.Advance(time.Second)
+	if _, ok := c.Get("a"); ok {
+		t.Error("entry still hit at exactly TTL; boundary should expire")
+	}
+}
+
+func TestPutRestartsTTL(t *testing.T) {
+	clk := newClock()
+	c := newTestCache(clk, time.Minute, 10)
+	c.Put("a", 1)
+	clk.Advance(50 * time.Second)
+	c.Put("a", 2) // restarts the clock for this key
+	clk.Advance(50 * time.Second)
+
+	got, ok := c.Get("a")
+	if !ok {
+		t.Fatal("re-Put entry expired on the original TTL")
+	}
+	if got != 2 {
+		t.Errorf("Get = %d, want 2 (the re-Put value)", got)
+	}
+}
+
+func TestInvalidateDropsEntry(t *testing.T) {
+	c := newTestCache(newClock(), time.Minute, 10)
+	c.Put("a", 1)
+	c.Invalidate("a")
+	if _, ok := c.Get("a"); ok {
+		t.Error("Get hit after Invalidate")
+	}
+}
+
+func TestInvalidateUnknownKeyIsSafe(t *testing.T) {
+	c := newTestCache(newClock(), time.Minute, 10)
+	c.Invalidate("never-cached") // must not panic
+	if c.Len() != 0 {
+		t.Errorf("Len = %d, want 0", c.Len())
+	}
+}
+
+func TestCacheIsBoundedByMaxEntries(t *testing.T) {
+	c := newTestCache(newClock(), time.Minute, 3)
+	for _, k := range []string{"a", "b", "c", "d", "e"} {
+		c.Put(k, 1)
+	}
+	if got := c.Len(); got > 3 {
+		t.Errorf("Len = %d, want <= 3 (MaxEntries must bound the map)", got)
+	}
+}
+
+func TestEvictionPrefersExpiredOverLive(t *testing.T) {
+	clk := newClock()
+	c := newTestCache(clk, time.Minute, 2)
+
+	c.Put("stale", 1)
+	clk.Advance(2 * time.Minute) // "stale" is now expired
+	c.Put("live", 2)             // fresh
+	c.Put("new", 3)              // at cap → must reclaim "stale", not "live"
+
+	if _, ok := c.Get("live"); !ok {
+		t.Error("a live entry was evicted while an expired one remained")
+	}
+	if _, ok := c.Get("new"); !ok {
+		t.Error("the just-inserted entry is missing")
+	}
+}
+
+func TestEvictionFallsBackToNearestExpiryWhenAllLive(t *testing.T) {
+	clk := newClock()
+	c := newTestCache(clk, time.Minute, 2)
+
+	c.Put("oldest", 1) // expires first
+	clk.Advance(10 * time.Second)
+	c.Put("newer", 2)
+	clk.Advance(10 * time.Second)
+	c.Put("newest", 3) // at cap, nothing expired → evict "oldest"
+
+	if _, ok := c.Get("oldest"); ok {
+		t.Error("expected the entry nearest expiry to be evicted")
+	}
+	for _, k := range []string{"newer", "newest"} {
+		if _, ok := c.Get(k); !ok {
+			t.Errorf("%q was evicted; expected it to survive", k)
+		}
+	}
+}
+
+func TestOverwriteAtCapacityDoesNotEvict(t *testing.T) {
+	c := newTestCache(newClock(), time.Minute, 2)
+	c.Put("a", 1)
+	c.Put("b", 2)
+	c.Put("a", 99) // replaces, doesn't grow — must not evict "b"
+
+	if _, ok := c.Get("b"); !ok {
+		t.Error("overwriting an existing key at capacity evicted another entry")
+	}
+	if got, _ := c.Get("a"); got != 99 {
+		t.Errorf("Get(a) = %d, want 99", got)
+	}
+}
+
+func TestNonPositiveTTLDisablesTheCache(t *testing.T) {
+	// A disabled cache is a supported state, not a misconfiguration: it lets a
+	// caller turn caching off from config without nil-checking every call site.
+	clk := newClock()
+	c := newTestCache(clk, 0, 10)
+	c.Put("a", 1)
+	if _, ok := c.Get("a"); ok {
+		t.Error("Get hit on a TTL<=0 cache; it should be disabled")
+	}
+	if c.Len() != 0 {
+		t.Errorf("Len = %d, want 0 — Put should no-op when disabled", c.Len())
+	}
+}
+
+func TestNonPositiveMaxEntriesFallsBackToDefault(t *testing.T) {
+	clk := newClock()
+	c := newTestCache(clk, time.Minute, 0)
+	c.Put("a", 1)
+	if _, ok := c.Get("a"); !ok {
+		t.Error("cache with MaxEntries<=0 should still work (default bound applies)")
+	}
+}
+
+func TestConcurrentAccessIsRaceFree(t *testing.T) {
+	// Meaningful under `go test -race`, which CI runs.
+	c := newTestCache(newClock(), time.Minute, 64)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				c.Put("k", j)
+				c.Get("k")
+				c.Invalidate("k")
+				c.Len()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/terraform/modules/desirelines/cloud_run.tf
+++ b/terraform/modules/desirelines/cloud_run.tf
@@ -47,7 +47,13 @@ resource "google_cloud_run_v2_service" "dispatcher" {
       min_instance_count = 0
     }
 
-    max_instance_request_concurrency = 1 # Serialize webhook processing to avoid token refresh races
+    # Serialize webhook processing. Two independent reasons now depend on this:
+    #   1. avoids token-refresh races (the original reason), and
+    #   2. makes the in-process allowlist/token caches' read-through-then-Put
+    #      pattern race-free (see adapters/cache/token_store.go DefaultTokenCacheTTL).
+    # Raising this (or max_instance_count) requires a per-key generation check in
+    # the cache read-through first, or a stale entry can be re-cached for a full TTL.
+    max_instance_request_concurrency = 1
 
     containers {
       image = "${local.image_base_url}/dispatcher:${var.deployment_version}"
@@ -89,6 +95,19 @@ resource "google_cloud_run_v2_service" "dispatcher" {
       env {
         name  = "FIRESTORE_DATABASE"
         value = google_firestore_database.user_configs.name
+      }
+
+      # Firestore-lookup cache kill switches. Default "5m"; set to "0" to disable a
+      # cache in place during a suspected-staleness incident (GitOps apply, no code
+      # change). See packages/dispatcher/config/config.go.
+      env {
+        name  = "ALLOWLIST_CACHE_TTL"
+        value = var.app_config.dispatcher_allowlist_cache_ttl
+      }
+
+      env {
+        name  = "TOKEN_CACHE_TTL"
+        value = var.app_config.dispatcher_token_cache_ttl
       }
 
       startup_probe {

--- a/terraform/modules/desirelines/variables.tf
+++ b/terraform/modules/desirelines/variables.tf
@@ -131,6 +131,11 @@ variable "app_config" {
     log_level         = string
     frontend_url      = optional(string, "")
     auth_callback_url = optional(string, "")
+    # Dispatcher Firestore-lookup cache TTLs (Go duration strings, e.g. "5m").
+    # "0" disables the respective cache — the incident kill switch for a suspected
+    # staleness bug, settable via GitOps with no code change.
+    dispatcher_allowlist_cache_ttl = optional(string, "5m")
+    dispatcher_token_cache_ttl     = optional(string, "5m")
   })
   default = {
     log_level = "INFO"


### PR DESCRIPTION
The dispatcher made two strictly-serial Firestore round-trips before it could call Strava on every webhook — allowlist check (~45ms) then token fetch (~42ms) — ~87ms of avoidable latency on the synchronous path that must finish before the ~2s Strava webhook ack.

Add a small bounded, TTL-expiring generic cache (packages/shared/ttlcache) and two read-through decorators over the existing ports:

  - allowlist.CachingChecker (shared, since the Checker interface is shared)
  - dispatcher/adapters/cache.TokenStore

Both keyed by athlete, both stamping cache.hit on the active span so a hit stays visible in traces rather than becoming a blind spot.

Consistency is by explicit invalidation, with the TTL as a backstop — not the other way around:

  - Tokens invalidate on every local mutation (write / delete) and on a rejected refresh (ports.TokenInvalidator, called from the Strava client), so a poisoned entry isn't re-served and the next read can pick up tokens the apigateway wrote out-of-process on re-auth. Cached by value, handed out as copies.
  - The allowlist caches ONLY positive decisions and invalidates on deauth (allowlist.Invalidator, called from the deauth handler). A cached "allowed" that outlived a deauth would trip the HIGH orphan alert; a cached "not allowed" would silently drop a re-authorized athlete's event. Negatives fail fresh.

Kill switch: ALLOWLIST_CACHE_TTL / TOKEN_CACHE_TTL (default "5m", wired in cloud_run.tf). "0" disables the respective cache in place via GitOps — no code change.

Both caches' read-through is race-free only because the dispatcher runs one request at a time (max_instance_count=1, max_instance_request_concurrency=1). That coupling is documented at both ends; raising either knob requires a per-key generation check first (tracked separately).