### PR TITLE
docs(api): correct openapi response shapes and document multi-sport mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Lint proto files
         run: just proto-lint
 
+      - name: Check proto formatting
+        run: just proto-fmt-check
+
       - name: Check proto breaking changes
         if: github.event_name == 'pull_request'
         run: |

--- a/justfiles/backend.just
+++ b/justfiles/backend.just
@@ -257,3 +257,23 @@ proto-breaking:
 proto-fmt:
     @echo "🎨 Formatting protobuf files..."
     buf format -w schemas/proto
+
+# Verify protobuf files are buf-formatted, without mutating the working tree.
+# Exits non-zero with the diff printed if any file needs reformatting.
+#
+# This also guards a subtler trap: bq_activities.proto is GENERATED
+# (schemas/bigquery/generate_proto.py) but still lives under schemas/proto, so
+# `buf format` rewrites it too. If the generator's output ever drifts from buf's
+# canonical form, `just format` silently dirties the file and the next
+# `just verify-schemas` fails with a confusing "BQ proto out of sync". Catching
+# it here names the real cause at PR time instead.
+proto-fmt-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "🎨 Checking proto formatting with buf..."
+    if ! buf format -d --exit-code schemas/proto; then
+        echo "❌ Protos not formatted. Run 'just proto-fmt' and commit."
+        echo "   If the diff is in a GENERATED proto (e.g. bq_activities.proto),"
+        echo "   fix the generator's output instead — see generate_proto.py."
+        exit 1
+    fi

--- a/packages/apigateway/handler_test.go
+++ b/packages/apigateway/handler_test.go
@@ -27,6 +27,7 @@ import (
 	activitiesv1 "github.com/andy-esch/desirelines/packages/apigateway/types/generated/activitiesv1"
 	"github.com/andy-esch/desirelines/packages/shared/ratelimit"
 	"github.com/go-chi/chi/v5"
+	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1421,4 +1422,87 @@ func TestValidateDateRange(t *testing.T) {
 			t.Error("expected error for range > 366 days")
 		}
 	})
+}
+
+// TestOpenAPISchemaFieldsMatchProtoJSON guards the response-field half of the
+// spec contract. TestRoutesMatchOpenAPISpec above compares paths and methods
+// only, so nothing caught openapi.yaml documenting snake_case field names for
+// years while the gateway marshals with protojson (UseProtoNames: false) and
+// emits camelCase — a client generated from the spec looked for fields the API
+// never returns. This asserts every documented property of a protobuf-backed
+// schema is a real protojson field name.
+//
+// Only schemas served through respondProtobuf belong here. Responses built from
+// hand-written Go structs (RegionSummary, HealthResponse, Error, SportCategory)
+// are marshaled by encoding/json and follow their struct tags instead.
+func TestOpenAPISchemaFieldsMatchProtoJSON(t *testing.T) {
+	schemaMessages := map[string]proto.Message{
+		"Activity":                    &activitiesv1.Activity{},
+		"ActivitySummary":             &activitiesv1.ActivitySummary{},
+		"ActivityListResponse":        &activitiesv1.ListActivitiesResponse{},
+		"ActivityBucket":              &activitiesv1.ActivityBucket{},
+		"AggregateActivitiesResponse": &activitiesv1.AggregateActivitiesResponse{},
+		"MapActivity":                 &activitiesv1.MapActivity{},
+		"YearMetadata":                &generated.YearMetadata{},
+		"SportTotals":                 &generated.SportTotals{},
+		"SportMetrics":                &generated.SportMetrics{},
+		"CumulativeMetricsEntry":      &generated.CumulativeMetricsEntry{},
+		"DailySummary":                &generated.DailySummary{},
+		"DailyActivity":               &generated.DailyActivity{},
+		"AllSportsMetrics":            &generated.AllSportsMetrics{},
+		"AllSportsDailySummary":       &generated.AllSportsDailySummary{},
+	}
+
+	specData, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatalf("failed to read openapi.yaml: %v", err)
+	}
+	var spec struct {
+		Components struct {
+			Schemas map[string]struct {
+				Properties map[string]interface{} `yaml:"properties"`
+				Required   []string               `yaml:"required"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if unmarshalErr := yaml.Unmarshal(specData, &spec); unmarshalErr != nil {
+		t.Fatalf("failed to parse openapi.yaml: %v", unmarshalErr)
+	}
+
+	for schemaName, msg := range schemaMessages {
+		t.Run(schemaName, func(t *testing.T) {
+			schema, ok := spec.Components.Schemas[schemaName]
+			if !ok {
+				t.Fatalf("openapi.yaml has no schema %q", schemaName)
+			}
+
+			// protojson (UseProtoNames: false) emits each field's JSON name.
+			fields := msg.ProtoReflect().Descriptor().Fields()
+			wire := make(map[string]bool, fields.Len())
+			for i := range fields.Len() {
+				wire[fields.Get(i).JSONName()] = true
+			}
+
+			for prop := range schema.Properties {
+				if !wire[prop] {
+					t.Errorf("schema documents %q, which is not a protojson field name (proto emits %v)",
+						prop, sortedKeys(wire))
+				}
+			}
+			for _, req := range schema.Required {
+				if !wire[req] {
+					t.Errorf("schema marks %q required, but it is not a protojson field name", req)
+				}
+			}
+		})
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
 }

--- a/packages/apigateway/openapi.yaml
+++ b/packages/apigateway/openapi.yaml
@@ -533,13 +533,19 @@ paths:
       parameters:
         - $ref: '#/components/parameters/year'
         - $ref: '#/components/parameters/sport'
+        - $ref: '#/components/parameters/sports'
       responses:
         '200':
-          description: Cumulative metrics timeseries
+          description: >-
+            Cumulative metrics. The shape depends on which sport parameter was
+            used: `sport` (singular) returns one sport's `SportMetrics`;
+            `sports` (plural) returns `AllSportsMetrics`, keyed by category.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SportMetrics'
+                oneOf:
+                  - $ref: '#/components/schemas/SportMetrics'
+                  - $ref: '#/components/schemas/AllSportsMetrics'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -558,13 +564,20 @@ paths:
       parameters:
         - $ref: '#/components/parameters/year'
         - $ref: '#/components/parameters/sport'
+        - $ref: '#/components/parameters/sports'
       responses:
         '200':
-          description: Daily summaries keyed by date
+          description: >-
+            Daily summaries keyed by date. The shape depends on which sport
+            parameter was used: `sport` (singular) returns one sport's
+            `DailySummary`; `sports` (plural) returns `AllSportsDailySummary`,
+            keyed by category.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DailySummary'
+                oneOf:
+                  - $ref: '#/components/schemas/DailySummary'
+                  - $ref: '#/components/schemas/AllSportsDailySummary'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -594,16 +607,34 @@ components:
     sport:
       name: sport
       in: query
-      required: true
+      required: false
       description: >-
-        Sport category. The canonical list of valid values is returned by
-        `GET /v1/sports/config` (sourced from
+        Single sport category. Supply **either** this or `sports` (plural):
+        endpoints accepting both require one of the two, and when both are
+        present `sports` wins and this is ignored. The canonical list of valid
+        values is returned by `GET /v1/sports/config` (sourced from
         `schemas/sports/sport_types.json`). Common examples: cycling,
         running, hiking, swimming, yoga, walking. Enum intentionally
         omitted so the spec doesn't go stale when categories are
         added — fetch the live list from the endpoint instead.
       schema:
         type: string
+        example: cycling
+    sports:
+      name: sports
+      in: query
+      required: false
+      description: >-
+        Multiple sport categories, comma-separated — the multi-sport form of
+        `sport`, returning one entry per category rather than a single sport's
+        data. At most 20 categories; entries are trimmed and empty ones
+        skipped; an unknown category fails the whole request with a 400.
+        Supply **either** this or `sport`: one of the two is required, and
+        `sports` wins if both are sent. Valid values come from
+        `GET /v1/sports/config`, as with `sport`.
+      schema:
+        type: string
+        example: cycling,running
 
   responses:
     BadRequest:
@@ -686,15 +717,15 @@ components:
         $ref: '#/components/schemas/SportCategory'
       example:
         cycling:
-          display_name: Cycling
-          strava_types: [Ride, VirtualRide, EBikeRide]
+          displayName: Cycling
+          stravaTypes: [Ride, VirtualRide, EBikeRide]
 
     SportCategory:
       type: object
       properties:
-        display_name:
+        displayName:
           type: string
-        strava_types:
+        stravaTypes:
           type: array
           items:
             type: string
@@ -702,12 +733,14 @@ components:
     Activity:
       type: object
       description: Full activity details
-      required: [id, name, type, sport, start_date_local, distance_meters, moving_time_seconds, elapsed_time_seconds]
+      required: [id, name, type, sport, startDateLocal, distanceMeters, movingTimeSeconds, elapsedTimeSeconds]
       properties:
         id:
-          type: integer
-          format: int64
-          description: Strava activity ID
+          type: string
+          description: >-
+            Strava activity ID. Serialized as a **string**: the API marshals
+            protobuf `int64` fields as JSON strings (protojson), so this is a
+            numeric id in string form.
         name:
           type: string
           description: Activity name
@@ -720,37 +753,37 @@ components:
             Categorized sport. See `GET /v1/sports/config` for the full
             list of categories (sourced from
             `schemas/sports/sport_types.json`).
-        start_date_local:
+        startDateLocal:
           type: string
           format: date-time
           description: Activity start time in local timezone
-        distance_meters:
+        distanceMeters:
           type: number
           format: double
           description: Distance in meters
-        moving_time_seconds:
+        movingTimeSeconds:
           type: integer
           description: Moving time in seconds
-        elapsed_time_seconds:
+        elapsedTimeSeconds:
           type: integer
           description: Total elapsed time in seconds
-        elevation_meters:
+        elevationMeters:
           type: number
           format: double
           description: Total elevation gain in meters
-        average_speed_mps:
+        averageSpeedMps:
           type: number
           format: double
           description: Average speed in m/s
-        max_speed_mps:
+        maxSpeedMps:
           type: number
           format: double
           description: Max speed in m/s
-        average_heartrate:
+        averageHeartrate:
           type: number
           format: double
           description: Average heart rate (bpm)
-        max_heartrate:
+        maxHeartrate:
           type: number
           format: double
           description: Max heart rate (bpm)
@@ -758,29 +791,32 @@ components:
     ActivitySummary:
       type: object
       description: Condensed activity for list views
-      required: [id, name, type, sport, start_date_local, distance_meters, moving_time_seconds, has_route]
+      required: [id, name, type, sport, startDateLocal, distanceMeters, movingTimeSeconds, hasRoute]
       properties:
         id:
-          type: integer
-          format: int64
+          type: string
+          description: >-
+            Strava activity ID. Serialized as a **string**: the API marshals
+            protobuf `int64` fields as JSON strings (protojson), so this is a
+            numeric id in string form.
         name:
           type: string
         type:
           type: string
         sport:
           type: string
-        start_date_local:
+        startDateLocal:
           type: string
           format: date-time
-        distance_meters:
+        distanceMeters:
           type: number
           format: double
-        moving_time_seconds:
+        movingTimeSeconds:
           type: integer
-        elevation_meters:
+        elevationMeters:
           type: number
           format: double
-        has_route:
+        hasRoute:
           type: boolean
           description: >-
             True when the activity is tagged to >=1 region and thus appears on
@@ -790,22 +826,22 @@ components:
 
     ActivityListResponse:
       type: object
-      required: [activities, has_more]
+      required: [activities, hasMore]
       properties:
         activities:
           type: array
           items:
             $ref: '#/components/schemas/ActivitySummary'
-        next_cursor:
+        nextCursor:
           type: string
           description: Cursor for fetching next page (base64 encoded)
-        has_more:
+        hasMore:
           type: boolean
           description: Whether more results are available
 
     ActivityBucket:
       type: object
-      required: [month, sport, geographic, count, moving_time_seconds, distance_meters]
+      required: [month, sport, geographic, count, movingTimeSeconds, distanceMeters]
       properties:
         month:
           type: string
@@ -822,10 +858,10 @@ components:
         count:
           type: integer
           description: Number of activities in the group
-        moving_time_seconds:
+        movingTimeSeconds:
           type: integer
           description: Summed moving time in seconds
-        distance_meters:
+        distanceMeters:
           type: number
           description: Summed distance in meters (zero for distance-less sports)
 
@@ -840,7 +876,7 @@ components:
 
     YearMetadata:
       type: object
-      required: [year, sports, totals, aggregation_version]
+      required: [year, sports, totals, aggregationVersion]
       properties:
         year:
           type: integer
@@ -853,22 +889,22 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/SportTotals'
-        last_updated:
+        lastUpdated:
           type: string
           format: date-time
-        aggregation_version:
+        aggregationVersion:
           type: string
 
     SportTotals:
       type: object
       properties:
-        distance_meters:
+        distanceMeters:
           type: number
           format: double
-        time_minutes:
+        timeMinutes:
           type: number
           format: double
-        elevation_meters:
+        elevationMeters:
           type: number
           format: double
         activities:
@@ -882,6 +918,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CumulativeMetricsEntry'
+
+    AllSportsMetrics:
+      type: object
+      description: >-
+        Multi-sport cumulative metrics, returned when the request used
+        `?sports=` (plural). One entry per requested category.
+      required: [bySport]
+      properties:
+        bySport:
+          type: object
+          description: Cumulative metrics keyed by sport category (e.g. "cycling").
+          additionalProperties:
+            $ref: '#/components/schemas/SportMetrics'
+
+    AllSportsDailySummary:
+      type: object
+      description: >-
+        Multi-sport daily summaries, returned when the request used `?sports=`
+        (plural). One entry per requested category.
+      required: [bySport]
+      properties:
+        bySport:
+          type: object
+          description: Daily summaries keyed by sport category (e.g. "cycling").
+          additionalProperties:
+            $ref: '#/components/schemas/DailySummary'
 
     CumulativeMetricsEntry:
       type: object
@@ -943,9 +1005,11 @@ components:
       required: [activityId, name, sport, distanceMeters, movingTime, startDateLocal, regionIds]
       properties:
         activityId:
-          type: integer
-          format: int64
-          description: Strava activity ID
+          type: string
+          description: >-
+            Strava activity ID. Serialized as a **string**: the API marshals
+            protobuf `int64` fields as JSON strings (protojson), so this is a
+            numeric id in string form.
         name:
           type: string
           description: Activity name/title
@@ -972,8 +1036,7 @@ components:
             Region ids this activity is tagged to. Same ids as
             GET /v1/activities/map/regions returns.
           items:
-            type: integer
-            format: int64
+            type: string
         bbox:
           type: array
           description: >-
@@ -994,19 +1057,18 @@ components:
     DailyActivity:
       type: object
       properties:
-        distance_meters:
+        distanceMeters:
           type: number
           format: double
-        time_minutes:
+        timeMinutes:
           type: number
           format: double
-        elevation_meters:
+        elevationMeters:
           type: number
           format: double
         activities:
           type: integer
-        activity_ids:
+        activityIds:
           type: array
           items:
-            type: integer
-            format: int64
+            type: string

--- a/schemas/bigquery/generate_proto.py
+++ b/schemas/bigquery/generate_proto.py
@@ -152,11 +152,18 @@ def _emit_field(col: dict[str, Any], field_number: int, out: _Emit) -> None:
         prefix = "optional "
 
     # Add a tag comment for TIMESTAMP/JSON so readers know the BQ semantics.
+    #
+    # Exactly ONE space before `//`: this file is generated, but it still lives
+    # under schemas/proto, so `just format` runs `buf format -w` over it. buf
+    # normalizes trailing comments to a single space, so emitting two would make
+    # format and `--check` disagree — running `just format` would leave this file
+    # dirty and fail `just verify-schemas` until it was regenerated. Keep the
+    # generator's output byte-identical to buf's canonical form.
     suffix = ""
     if bq_type == "TIMESTAMP":
-        suffix = "  // BQ TIMESTAMP — micros since epoch"
+        suffix = " // BQ TIMESTAMP — micros since epoch"
     elif bq_type == "JSON":
-        suffix = "  // BQ JSON — JSON-encoded string"
+        suffix = " // BQ JSON — JSON-encoded string"
 
     out.write(f"{prefix}{type_name} {name} = {field_number};{suffix}")
 

--- a/schemas/proto/desirelines/bigquery/v1/bq_activities.proto
+++ b/schemas/proto/desirelines/bigquery/v1/bq_activities.proto
@@ -52,7 +52,7 @@ message Activity {
       // Unique photo ID
       optional string unique_id = 4;
       // Photo URLs as JSON
-      optional string urls = 5;  // BQ JSON — JSON-encoded string
+      optional string urls = 5; // BQ JSON — JSON-encoded string
     }
 
     // Primary photo
@@ -113,8 +113,8 @@ message Activity {
     optional Athlete athlete = 5;
     optional int64 elapsed_time = 6;
     optional int64 moving_time = 7;
-    optional int64 start_date = 8;  // BQ TIMESTAMP — micros since epoch
-    optional int64 start_date_local = 9;  // BQ TIMESTAMP — micros since epoch
+    optional int64 start_date = 8; // BQ TIMESTAMP — micros since epoch
+    optional int64 start_date_local = 9; // BQ TIMESTAMP — micros since epoch
     optional double distance = 10;
     optional int64 start_index = 11;
     optional int64 end_index = 12;
@@ -165,8 +165,8 @@ message Activity {
     optional Athlete athlete = 5;
     optional int64 elapsed_time = 6;
     optional int64 moving_time = 7;
-    optional int64 start_date = 8;  // BQ TIMESTAMP — micros since epoch
-    optional int64 start_date_local = 9;  // BQ TIMESTAMP — micros since epoch
+    optional int64 start_date = 8; // BQ TIMESTAMP — micros since epoch
+    optional int64 start_date_local = 9; // BQ TIMESTAMP — micros since epoch
     optional double distance = 10;
     optional int64 start_index = 11;
     optional int64 end_index = 12;
@@ -219,8 +219,8 @@ message Activity {
     optional Athlete athlete = 5;
     optional int64 elapsed_time = 6;
     optional int64 moving_time = 7;
-    optional int64 start_date = 8;  // BQ TIMESTAMP — micros since epoch
-    optional int64 start_date_local = 9;  // BQ TIMESTAMP — micros since epoch
+    optional int64 start_date = 8; // BQ TIMESTAMP — micros since epoch
+    optional int64 start_date_local = 9; // BQ TIMESTAMP — micros since epoch
     optional double distance = 10;
     optional int64 start_index = 11;
     optional int64 end_index = 12;
@@ -265,9 +265,9 @@ message Activity {
   // Sport type classification
   optional string sport_type = 13;
   // Activity start time (UTC)
-  optional int64 start_date = 14;  // BQ TIMESTAMP — micros since epoch
+  optional int64 start_date = 14; // BQ TIMESTAMP — micros since epoch
   // Activity start time in local timezone
-  optional int64 start_date_local = 15;  // BQ TIMESTAMP — micros since epoch
+  optional int64 start_date_local = 15; // BQ TIMESTAMP — micros since epoch
   // Timezone of the activity
   optional string timezone = 16;
   // Starting latitude and longitude coordinates

--- a/terraform/modules/desirelines/README.md
+++ b/terraform/modules/desirelines/README.md
@@ -10,7 +10,7 @@ Main Terraform module for the Desirelines project. Provisions all GCP resources 
 | `pubsub_subscriptions.tf` | Push subscriptions (activity + deauth), dead letter queues |
 | `main.tf` | Pub/Sub topics (activity_events, deauth_events, dead_letter), BigQuery dataset/tables, Firestore database, Cloud Storage, GCP APIs |
 | `firebase_hosting.tf` | Firebase Hosting site, custom domain, web app config |
-| `image_validation.tf` | Container image tag validation pre-apply (tag-based; complements the digest references below) |
+| `image_validation.tf` | Pre-apply check that every image reference a plan intends to deploy exists in Artifact Registry |
 | `monitoring.tf` | Monitoring alerts and notification channels |
 
 ## Usage
@@ -216,7 +216,7 @@ module "desirelines" {
 | <a name="input_enable_application_metric_alerts"></a> [enable\_application\_metric\_alerts](#input\_enable\_application\_metric\_alerts) | Gate for alert policies that reference custom OTel application metrics (postgres pool exhaustion, Strava/HTTP/Postgres/Firestore/PubSub latency tails). These policies target custom.googleapis.com/desirelines.io/* metric descriptors, which are auto-created by the OTel GCP exporter the first time the app emits each metric — so on a first-ever deploy they don't exist yet and `google_monitoring_alert_policy` returns 404 when it tries to bind to them. Leave false on the initial deploy; after the services have run long enough to flush at least one metrics batch (≥ 60s), flip true on a follow-up apply. | `bool` | `false` | no |
 | <a name="input_firestore_location"></a> [firestore\_location](#input\_firestore\_location) | Firestore database location (region ID, e.g., 'us-central1') | `string` | `"us-central1"` | no |
 | <a name="input_gcp_region"></a> [gcp\_region](#input\_gcp\_region) | Default GCP region | `string` | `"us-central1"` | no |
-| <a name="input_image_digests"></a> [image\_digests](#input\_image\_digests) | Map of service name (dispatcher/apigateway/stravapipe) to image digest, e.g. {dispatcher = "sha256:abc..."}. Empty falls back to tag-based image references. | `map(string)` | `{}` | no |
+| <a name="input_image_digests"></a> [image\_digests](#input\_image\_digests) | Map of service name (dispatcher/apigateway/stravapipe) to the image digest that environment runs, e.g. {dispatcher = "sha256:abc..."}. Committed to tfvars by the deploy pipeline. Empty falls back to tag-based references (bootstrap only). | `map(string)` | `{}` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name of the project (used for resource naming) | `string` | `"desirelines"` | no |
 | <a name="input_readiness_probe_schedule"></a> [readiness\_probe\_schedule](#input\_readiness\_probe\_schedule) | Cron schedule (UTC) for the Cloud Scheduler /api/ready probe against apigateway. Default is hourly. Each invocation wakes Neon's compute for the 5-min idle window, so this is the dominant DB-active driver after stealth wakes are removed. NOTE: dropping below hourly requires retuning google\_monitoring\_alert\_policy.apigateway\_readiness\_failing — its 4h alignment window assumes ≥3 hourly samples per evaluation; reducing cadence balloons alert latency. | `string` | `"0 * * * *"` | no |
 | <a name="input_slack_notification_channel_id"></a> [slack\_notification\_channel\_id](#input\_slack\_notification\_channel\_id) | Full resource ID of an externally-managed Slack notification channel (format: projects/<project>/notificationChannels/<id>). Created once via GCP Console → Monitoring → Notification Channels → Slack OAuth flow; the channel is not managed by Terraform because the OAuth token is issued through the Console and kept out of state. Leave null to skip Slack notifications for this environment. | `string` | `null` | no |
@@ -231,7 +231,7 @@ module "desirelines" {
 | <a name="output_bigquery_table_full_id"></a> [bigquery\_table\_full\_id](#output\_bigquery\_table\_full\_id) | Full ID of the activities BigQuery table (project:dataset.table) |
 | <a name="output_bigquery_table_id"></a> [bigquery\_table\_id](#output\_bigquery\_table\_id) | ID of the activities BigQuery table |
 | <a name="output_cloud_run_urls"></a> [cloud\_run\_urls](#output\_cloud\_run\_urls) | Cloud Run service URLs (stable, do not change on redeploy) |
-| <a name="output_deployment_info"></a> [deployment\_info](#output\_deployment\_info) | Deployment provenance: image registry and version tag |
+| <a name="output_deployment_info"></a> [deployment\_info](#output\_deployment\_info) | Deployment provenance: image registry, version tag, and the exact image reference deployed per service |
 | <a name="output_firebase_custom_domain"></a> [firebase\_custom\_domain](#output\_firebase\_custom\_domain) | Custom domain for Firebase Hosting (production only) |
 | <a name="output_firebase_hosting_site_id"></a> [firebase\_hosting\_site\_id](#output\_firebase\_hosting\_site\_id) | Firebase Hosting site ID for web application |
 | <a name="output_firebase_hosting_url"></a> [firebase\_hosting\_url](#output\_firebase\_hosting\_url) | Default Firebase Hosting URL for web application |

--- a/terraform/modules/desirelines/cloud_run.tf
+++ b/terraform/modules/desirelines/cloud_run.tf
@@ -5,17 +5,26 @@
 locals {
   image_base_url = var.external_artifact_registry
 
-  # Image reference per service, preferring an immutable digest.
+  # Image reference per service, by immutable digest.
   #
   # A digest reference is byte-identical across commits that did not change the image, so
-  # Terraform sees no diff and creates no Cloud Run revision — which is the whole point
-  # (see `image_digests` in variables.tf). The tag form is the fallback for local or
-  # manual applies where no digest was resolved.
+  # Terraform sees no diff and creates no Cloud Run revision — which is the whole point.
+  # A tag reference carries the git SHA, so it changes on every commit and rolls a new
+  # revision for every service whether or not that service changed.
+  #
+  # `image_digests` is committed per environment rather than passed only at apply time.
+  # That matters beyond provenance: a digest supplied solely by the deploy pipeline makes
+  # this expression render differently depending on who runs it, so drift detection, a
+  # local plan, and a promotion PR all report every service as changed — the same image,
+  # spelled two ways.
+  #
+  # The tag form is a bootstrap fallback, for the first apply in an environment whose
+  # tfvars has no digests yet. Steady state should always take the digest branch.
   #
   # Defined once and reused by all six container blocks below; previously each one
   # interpolated the tag inline, so a change had to be made in six places.
   image_ref = {
-    for name in ["dispatcher", "apigateway", "stravapipe"] :
+    for name in local.cloud_run_images :
     name => (
       lookup(var.image_digests, name, "") != ""
       ? "${local.image_base_url}/${name}@${var.image_digests[name]}"

--- a/terraform/modules/desirelines/image_validation.tf
+++ b/terraform/modules/desirelines/image_validation.tf
@@ -1,25 +1,33 @@
 # Docker Image Validation
-# Validates that all required images exist in Artifact Registry before deployment.
-# Fails fast at plan time with clear error message if images are missing.
+# Validates that every image a plan intends to deploy actually exists in Artifact
+# Registry. Fails fast at plan time with a clear error message if one is missing.
+#
+# Validates `local.image_ref` — the exact reference the container blocks use — rather
+# than re-deriving one from the tag. Two reasons:
+#   1. Once digests are committed per environment, the tag for a given commit may not
+#      exist at all: a service whose source didn't change isn't rebuilt, so no tag is
+#      pushed for that version while its digest carries forward unchanged. Checking the
+#      tag would fail a plan that is entirely correct.
+#   2. It checks what will actually be deployed, so a digest that has since aged out of
+#      the registry is still caught.
+#
+# This lookup feeds preconditions only. Plan output does not depend on it, so the
+# rendered image reference stays a pure function of committed inputs.
 
 locals {
-  cloud_run_images = {
-    dispatcher = "dispatcher"
-    apigateway = "apigateway"
-    stravapipe = "stravapipe"
-  }
+  cloud_run_images = toset(["dispatcher", "apigateway", "stravapipe"])
 }
 
-# Check if each image exists in Artifact Registry
+# Check that each image reference resolves in Artifact Registry.
 # Returns {"exists": "true"} or {"exists": "false"}
 data "external" "image_exists" {
   for_each = local.cloud_run_images
 
   program = ["bash", "-c", <<-EOF
-    if gcloud artifacts docker images describe "${var.external_artifact_registry}/${each.value}:${var.deployment_version}" >/dev/null 2>&1; then
-      echo '{"exists":"true","image":"${each.value}:${var.deployment_version}"}'
+    if gcloud artifacts docker images describe "${local.image_ref[each.value]}" >/dev/null 2>&1; then
+      echo '{"exists":"true"}'
     else
-      echo '{"exists":"false","image":"${each.value}:${var.deployment_version}"}'
+      echo '{"exists":"false"}'
     fi
   EOF
   ]
@@ -30,15 +38,15 @@ resource "terraform_data" "image_validation" {
   lifecycle {
     precondition {
       condition     = data.external.image_exists["dispatcher"].result.exists == "true"
-      error_message = "Image not found: ${var.external_artifact_registry}/dispatcher:${var.deployment_version}\nRun 'just build-publish' first."
+      error_message = "Image not found: ${local.image_ref.dispatcher}\nRun 'just build-publish' first."
     }
     precondition {
       condition     = data.external.image_exists["apigateway"].result.exists == "true"
-      error_message = "Image not found: ${var.external_artifact_registry}/apigateway:${var.deployment_version}\nRun 'just build-publish' first."
+      error_message = "Image not found: ${local.image_ref.apigateway}\nRun 'just build-publish' first."
     }
     precondition {
       condition     = data.external.image_exists["stravapipe"].result.exists == "true"
-      error_message = "Image not found: ${var.external_artifact_registry}/stravapipe:${var.deployment_version}\nRun 'just build-publish' first."
+      error_message = "Image not found: ${local.image_ref.stravapipe}\nRun 'just build-publish' first."
     }
   }
 }

--- a/terraform/modules/desirelines/outputs.tf
+++ b/terraform/modules/desirelines/outputs.tf
@@ -94,10 +94,15 @@ output "service_names" {
 
 # Deployment information
 output "deployment_info" {
-  description = "Deployment provenance: image registry and version tag"
+  description = "Deployment provenance: image registry, version tag, and the exact image reference deployed per service"
   value = {
     image_base_url     = var.external_artifact_registry
     deployment_version = var.deployment_version
+
+    # The exact reference each service is running. Digest form in steady state; a
+    # tag here means that environment's tfvars carries no digest for the service,
+    # which is expected only on a bootstrap apply.
+    images = local.image_ref
   }
 }
 

--- a/terraform/modules/desirelines/variables.tf
+++ b/terraform/modules/desirelines/variables.tf
@@ -92,23 +92,31 @@ variable "deployment_version" {
   }
 }
 
-# Per-service image digests, resolved from tags by the deploy pipeline.
+# Per-service image digests — the images this environment actually runs.
 #
-# WHY THIS EXISTS: `deployment_version` is a git SHA, so the image reference string
-# changes on every commit even when the built bytes are identical. Terraform diffs the
-# string and creates a new Cloud Run revision for every service on every push — a real
-# traffic-shifting rollout for a service that did not change. Referencing an immutable
-# digest instead makes Terraform's own diff engine the guard: same bytes, no diff, no
-# revision.
+# WHY THIS EXISTS: `deployment_version` is a git SHA, so a tag reference changes on every
+# commit even when the built bytes are identical. Terraform diffs the string and creates
+# a new Cloud Run revision for every service on every push — a real traffic-shifting
+# rollout for a service that did not change. Referencing an immutable digest instead
+# makes Terraform's own diff engine the guard: same bytes, no diff, no revision.
 #
-# This is about deploy churn, not supply-chain immutability — Cloud Run already resolves
-# a tag to a digest and pins each revision to it.
+# WHY IT IS COMMITTED per environment rather than passed only at apply time: a value
+# supplied by one code path makes the rendered image reference depend on who ran the
+# plan, so every other plan — scheduled drift detection, a local `terraform plan`, a
+# promotion PR — renders the tag form instead and reports every Cloud Run service and
+# job as changed. Committing the digests also means git records the exact bytes each
+# environment runs: a revert restores an image, a promotion PR shows the image change in
+# its diff, and drift detection compares live infrastructure against declared intent
+# rather than against whatever a mutable tag happens to point at today.
 #
-# Empty (the default) falls back to tag-based references, which preserves local/manual
-# `terraform apply`. The deploy pipeline is expected to always populate it; if it stops,
-# the no-op revisions come back silently.
+# This is about deploy churn and provenance, not supply-chain immutability — Cloud Run
+# already resolves a tag to a digest and pins each revision to it.
+#
+# Empty (the default) falls back to tag-based references. That is a bootstrap path, for
+# the first apply in an environment whose tfvars has no digests yet; the deploy pipeline
+# writes them on success. If it stops, the no-op revisions come back.
 variable "image_digests" {
-  description = "Map of service name (dispatcher/apigateway/stravapipe) to image digest, e.g. {dispatcher = \"sha256:abc...\"}. Empty falls back to tag-based image references."
+  description = "Map of service name (dispatcher/apigateway/stravapipe) to the image digest that environment runs, e.g. {dispatcher = \"sha256:abc...\"}. Committed to tfvars by the deploy pipeline. Empty falls back to tag-based references (bootstrap only)."
   type        = map(string)
   default     = {}
 


### PR DESCRIPTION
The spec described response fields the API has never emitted, and omitted the plural sport query mode entirely.

- rename response-schema properties to camelCase across 8 schemas: the gateway marshals with protojson (UseProtoNames: false), so it emits JSON names, not proto names. Query parameters are untouched — those really are snake_case on the wire
- type protojson int64 fields (id, activityId, regionIds, activityIds) as strings, which is what protojson emits; the web already coerces these at its zod boundary. RegionSummary.regionId stays an integer — it comes from a Go struct via encoding/json, where int64 is a number
- document the ?sports= (plural) parameter on the metrics and source endpoints, including the max-20 cap and 400-on-unknown, and note that it wins over ?sport= when both are sent
- document the response shapes that mode returns: AllSportsMetrics and AllSportsDailySummary, keyed by bySport, as a oneOf against the single-sport schemas
- add TestOpenAPISchemaFieldsMatchProtoJSON, which reflects over each protobuf-backed schema and fails if the spec documents a field name protojson would not emit — the existing route-drift test compares only paths and methods, which is why this drift went unnoticed