### PR TITLE
feat(backfill): upsert activities and report write metrics

### DIFF
--- a/packages/stravapipe/src/stravapipe/application/backfill/__init__.py
+++ b/packages/stravapipe/src/stravapipe/application/backfill/__init__.py
@@ -4,6 +4,7 @@ from stravapipe.application.backfill.service import (
     BackfillResult,
     BackfillService,
     NoOpProgressReporter,
+    PostgresWriteStats,
     ProgressReporter,
     YearStats,
 )
@@ -12,6 +13,7 @@ __all__ = [
     "BackfillResult",
     "BackfillService",
     "NoOpProgressReporter",
+    "PostgresWriteStats",
     "ProgressReporter",
     "YearStats",
 ]

--- a/packages/stravapipe/src/stravapipe/application/backfill/service.py
+++ b/packages/stravapipe/src/stravapipe/application/backfill/service.py
@@ -11,6 +11,7 @@ fetching entire years of activities and inserting in batches.
 
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
+from functools import partial
 import logging
 import time
 from typing import Protocol
@@ -23,6 +24,7 @@ from stravapipe.domain import (
     StandardActivity,
     SummaryStravaActivity,
 )
+from stravapipe.ports.out.postgres import ActivityRepository
 from stravapipe.ports.out.read import ReadDetailedActivities
 from stravapipe.ports.out.unit_of_work import AbstractUnitOfWork
 
@@ -44,6 +46,18 @@ def _iter_batches[T](
     total = (len(seq) + size - 1) // size
     for batch_num, i in enumerate(range(0, len(seq), size), start=1):
         yield batch_num, total, seq[i : i + size]
+
+
+def _upsert_activity(
+    repository: ActivityRepository,
+    activity: StandardActivity,
+) -> None:
+    """Upsert one activity, failing loudly if the repository affects no row."""
+    success = repository.upsert(activity)
+    if not success:
+        raise RuntimeError(
+            f"PostgreSQL upsert affected no row for activity {activity.id}"
+        )
 
 
 # Bounded in-batch retry around the BQ Storage Write API. Cloud Run Jobs
@@ -72,11 +86,20 @@ class YearStats:
     year: int
     activities_found: int = 0
     pg_inserted: int = 0
-    pg_skipped: int = 0
+    pg_updated: int = 0
     pg_errors: int = 0
     bq_inserted: int = 0
     bq_errors: int = 0
     duration_seconds: float = 0.0
+
+
+@dataclass
+class PostgresWriteStats:
+    """Committed PostgreSQL activity-write outcomes."""
+
+    inserted: int = 0
+    updated: int = 0
+    errors: int = 0
 
 
 @dataclass
@@ -88,6 +111,7 @@ class BackfillResult:
     year_stats: list[YearStats] = field(default_factory=list)
     total_activities: int = 0
     total_pg_inserted: int = 0
+    total_pg_updated: int = 0
     total_bq_inserted: int = 0
     total_errors: int = 0
     duration_seconds: float = 0.0
@@ -102,9 +126,7 @@ class ProgressReporter(Protocol):
 
     def report_started(self, athlete_id: str, years: list[int]) -> None: ...
 
-    def report_year_complete(
-        self, athlete_id: str, year: int, activities_count: int
-    ) -> None: ...
+    def report_year_complete(self, athlete_id: str, stats: YearStats) -> None: ...
 
     def report_completed(self, athlete_id: str, result: BackfillResult) -> None: ...
 
@@ -117,9 +139,7 @@ class NoOpProgressReporter:
     def report_started(self, athlete_id: str, years: list[int]) -> None:
         pass
 
-    def report_year_complete(
-        self, athlete_id: str, year: int, activities_count: int
-    ) -> None:
+    def report_year_complete(self, athlete_id: str, stats: YearStats) -> None:
         pass
 
     def report_completed(self, athlete_id: str, result: BackfillResult) -> None:
@@ -178,7 +198,11 @@ class BackfillService:
         sorted_years = sorted(years)
 
         result = BackfillResult(athlete_id=athlete_id, years=sorted_years)
-        self._progress.report_started(athlete_id, sorted_years)
+        self._report_progress(
+            "started",
+            athlete_id,
+            partial(self._progress.report_started, athlete_id, sorted_years),
+        )
 
         logger.info(
             "Starting backfill for athlete %s, years: %s",
@@ -192,11 +216,18 @@ class BackfillService:
                 result.year_stats.append(year_stats)
                 result.total_activities += year_stats.activities_found
                 result.total_pg_inserted += year_stats.pg_inserted
+                result.total_pg_updated += year_stats.pg_updated
                 result.total_bq_inserted += year_stats.bq_inserted
                 result.total_errors += year_stats.pg_errors + year_stats.bq_errors
 
-                self._progress.report_year_complete(
-                    athlete_id, year, year_stats.activities_found
+                self._report_progress(
+                    "year_complete",
+                    athlete_id,
+                    partial(
+                        self._progress.report_year_complete,
+                        athlete_id,
+                        year_stats,
+                    ),
                 )
             except Exception:
                 logger.exception(
@@ -208,31 +239,71 @@ class BackfillService:
                 result.total_errors += 1
 
         result.duration_seconds = time.monotonic() - start_time
+        year_count = len(sorted_years)
+        year_label = "year" if year_count == 1 else "years"
 
         if result.success:
-            self._progress.report_completed(athlete_id, result)
+            self._report_progress(
+                "completed",
+                athlete_id,
+                partial(self._progress.report_completed, athlete_id, result),
+            )
             logger.info(
-                "Backfill completed for athlete %s: %d activities across %d years "
-                "(PG: %d inserted, BQ: %d inserted) in %.1fs",
+                "Backfill completed for athlete %s: %d activities across %d %s "
+                "(PG: %d inserted, %d updated; "
+                "BQ: %d inserted; errors: %d) in %.1fs",
                 athlete_id,
                 result.total_activities,
-                len(sorted_years),
+                year_count,
+                year_label,
                 result.total_pg_inserted,
+                result.total_pg_updated,
                 result.total_bq_inserted,
+                result.total_errors,
                 result.duration_seconds,
             )
         else:
-            self._progress.report_failed(
+            self._report_progress(
+                "failed",
                 athlete_id,
-                f"Completed with {result.total_errors} errors",
+                partial(
+                    self._progress.report_failed,
+                    athlete_id,
+                    f"Completed with {result.total_errors} errors",
+                ),
             )
             logger.warning(
-                "Backfill completed with errors for athlete %s: %d errors",
+                "Backfill completed with errors for athlete %s: %d activities "
+                "across %d %s (PG: %d inserted, %d updated; "
+                "BQ: %d inserted; errors: %d) in %.1fs",
                 athlete_id,
+                result.total_activities,
+                year_count,
+                year_label,
+                result.total_pg_inserted,
+                result.total_pg_updated,
+                result.total_bq_inserted,
                 result.total_errors,
+                result.duration_seconds,
             )
 
         return result
+
+    @staticmethod
+    def _report_progress(
+        event: str,
+        athlete_id: str,
+        callback: Callable[[], None],
+    ) -> None:
+        """Report progress without letting control-plane failures alter data results."""
+        try:
+            callback()
+        except Exception:
+            logger.exception(
+                "Progress reporter failed during %s for athlete %s",
+                event,
+                athlete_id,
+            )
 
     def _backfill_year(self, year: int) -> YearStats:
         """Backfill a single year.
@@ -248,15 +319,18 @@ class BackfillService:
         logger.info("Found %d activities in %d", len(activities), year)
 
         if not activities:
-            return YearStats(year=year)
+            return YearStats(
+                year=year,
+                duration_seconds=time.monotonic() - start_time,
+            )
 
         stats = YearStats(year=year, activities_found=len(activities))
 
-        # Insert to PostgreSQL
-        pg_inserted, pg_skipped, pg_errors = self._insert_to_postgres(activities)
-        stats.pg_inserted = pg_inserted
-        stats.pg_skipped = pg_skipped
-        stats.pg_errors = pg_errors
+        # Upsert to PostgreSQL
+        pg_stats = self._insert_to_postgres(activities)
+        stats.pg_inserted = pg_stats.inserted
+        stats.pg_updated = pg_stats.updated
+        stats.pg_errors = pg_stats.errors
 
         # Insert to BigQuery (optional)
         if self._bq_writer is not None:
@@ -267,12 +341,12 @@ class BackfillService:
         stats.duration_seconds = time.monotonic() - start_time
 
         logger.info(
-            "Year %d complete in %.1fs: PG(%d inserted, %d skipped, %d errors), "
+            "Year %d complete in %.1fs: PG(%d inserted, %d updated, %d errors), "
             "BQ(%d inserted, %d errors)",
             year,
             stats.duration_seconds,
             stats.pg_inserted,
-            stats.pg_skipped,
+            stats.pg_updated,
             stats.pg_errors,
             stats.bq_inserted,
             stats.bq_errors,
@@ -283,50 +357,57 @@ class BackfillService:
     def _insert_to_postgres(
         self,
         activities: Sequence[DetailedStravaActivity | SummaryStravaActivity],
-    ) -> tuple[int, int, int]:
-        """Insert activities to PostgreSQL in batches.
+    ) -> PostgresWriteStats:
+        """Upsert activities to PostgreSQL in batches.
 
-        Returns:
-            Tuple of (inserted_count, skipped_count, error_count)
+        Inserted vs updated is classified from a batch pre-read. Counts are
+        promoted only after the surrounding transaction commits.
         """
-        inserted_count = 0
-        skipped_count = 0
-        error_count = 0
+        stats = PostgresWriteStats()
 
         for batch_num, total_batches, batch in _iter_batches(
             activities, self._batch_size
         ):
             try:
                 batch_inserted = 0
-                batch_skipped = 0
+                batch_updated = 0
 
                 uow = self._uow_factory()
                 with uow:
+                    existing_ids = uow.activities.get_existing_ids(
+                        [activity.id for activity in batch]
+                    )
                     for activity in batch:
                         standard = StandardActivity.model_validate(
                             activity, from_attributes=True
                         )
-                        if uow.activities.insert(standard):
-                            batch_inserted += 1
+                        _upsert_activity(uow.activities, standard)
+                        if activity.id in existing_ids:
+                            batch_updated += 1
                         else:
-                            batch_skipped += 1
+                            batch_inserted += 1
                     uow.commit()
 
-                inserted_count += batch_inserted
-                skipped_count += batch_skipped
+                stats.inserted += batch_inserted
+                stats.updated += batch_updated
 
                 logger.info(
-                    "PG batch %d/%d: %d inserted, %d skipped",
+                    "PG batch %d/%d: %d inserted, %d updated, 0 errors",
                     batch_num,
                     total_batches,
                     batch_inserted,
-                    batch_skipped,
+                    batch_updated,
                 )
             except Exception:
-                error_count += len(batch)
-                logger.exception("PG batch %d/%d failed", batch_num, total_batches)
+                stats.errors += len(batch)
+                logger.exception(
+                    "PG batch %d/%d: 0 inserted, 0 updated, %d errors",
+                    batch_num,
+                    total_batches,
+                    len(batch),
+                )
 
-        return inserted_count, skipped_count, error_count
+        return stats
 
     def _insert_to_bigquery(
         self,

--- a/packages/stravapipe/src/stravapipe/application/backfill/service.py
+++ b/packages/stravapipe/src/stravapipe/application/backfill/service.py
@@ -10,6 +10,7 @@ fetching entire years of activities and inserting in batches.
 """
 
 from collections.abc import Callable, Iterator, Sequence
+from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import partial
 import logging
@@ -122,7 +123,12 @@ class BackfillResult:
 
 
 class ProgressReporter(Protocol):
-    """Protocol for reporting backfill progress (e.g. to Firestore)."""
+    """Protocol for reporting backfill progress (e.g. to Firestore).
+
+    Mutable payloads are defensive snapshots. Reporter implementations may
+    retain or transform them without affecting the backfill's control flow or
+    returned result.
+    """
 
     def report_started(self, athlete_id: str, years: list[int]) -> None: ...
 
@@ -178,6 +184,9 @@ class BackfillService:
         progress_reporter: ProgressReporter | None = None,
         batch_size: int = BATCH_SIZE,
     ):
+        if batch_size <= 0:
+            raise ValueError("batch_size must be greater than zero")
+
         self._strava_reader = strava_reader
         self._uow_factory = uow_factory
         self._bq_writer = bq_writer
@@ -201,7 +210,11 @@ class BackfillService:
         self._report_progress(
             "started",
             athlete_id,
-            partial(self._progress.report_started, athlete_id, sorted_years),
+            partial(
+                self._progress.report_started,
+                athlete_id,
+                deepcopy(sorted_years),
+            ),
         )
 
         logger.info(
@@ -226,7 +239,7 @@ class BackfillService:
                     partial(
                         self._progress.report_year_complete,
                         athlete_id,
-                        year_stats,
+                        deepcopy(year_stats),
                     ),
                 )
             except Exception:
@@ -246,7 +259,11 @@ class BackfillService:
             self._report_progress(
                 "completed",
                 athlete_id,
-                partial(self._progress.report_completed, athlete_id, result),
+                partial(
+                    self._progress.report_completed,
+                    athlete_id,
+                    deepcopy(result),
+                ),
             )
             logger.info(
                 "Backfill completed for athlete %s: %d activities across %d %s "

--- a/packages/stravapipe/src/stravapipe/cloudrun/backfill_job.py
+++ b/packages/stravapipe/src/stravapipe/cloudrun/backfill_job.py
@@ -28,7 +28,7 @@ from stravapipe.adapters.firestore import FirestoreTokenStore
 from stravapipe.adapters.gcp import make_write_activities
 from stravapipe.adapters.postgres import SqlAlchemyUnitOfWork, create_session_factory
 from stravapipe.adapters.strava import create_strava_activities_repo
-from stravapipe.application.backfill import BackfillService
+from stravapipe.application.backfill import BackfillResult, BackfillService
 from stravapipe.config.backfill import load_backfill_config
 from stravapipe.domain import StravaTokenSet
 from stravapipe.shared.correlation import new_correlation_id
@@ -36,6 +36,24 @@ from stravapipe.shared.logging import setup_logging
 from stravapipe.shared.tracing import setup_tracing
 
 logger = setup_logging(__name__)
+
+
+def _log_result(result: BackfillResult) -> int:
+    """Log the terminal metric contract and return the process exit code."""
+    log = logger.info if result.success else logger.error
+    status = "succeeded" if result.success else "completed with errors"
+    log(
+        "Backfill %s: %d activities "
+        "(PG: %d inserted, %d updated; BQ: %d inserted; errors: %d) in %.1fs",
+        status,
+        result.total_activities,
+        result.total_pg_inserted,
+        result.total_pg_updated,
+        result.total_bq_inserted,
+        result.total_errors,
+        result.duration_seconds,
+    )
+    return 0 if result.success else 1
 
 
 def main() -> None:
@@ -116,18 +134,7 @@ def main() -> None:
 
     # --- Exit ---
 
-    if result.success:
-        logger.info(
-            "Backfill succeeded: %d activities (%d PG, %d BQ) in %.1fs",
-            result.total_activities,
-            result.total_pg_inserted,
-            result.total_bq_inserted,
-            result.duration_seconds,
-        )
-        sys.exit(0)
-    else:
-        logger.error("Backfill completed with %d errors", result.total_errors)
-        sys.exit(1)
+    sys.exit(_log_result(result))
 
 
 if __name__ == "__main__":

--- a/packages/stravapipe/src/stravapipe/config/backfill.py
+++ b/packages/stravapipe/src/stravapipe/config/backfill.py
@@ -66,7 +66,7 @@ class BackfillConfig(BaseSettings):
         description="Comma-separated years to backfill (e.g. '2023,2024,2025'). "
         "Defaults to current year.",
     )
-    batch_size: int = 100
+    batch_size: int = Field(default=100, gt=0)
 
     # Environment
     log_level: str = "INFO"

--- a/packages/stravapipe/tests/unit/application/backfill/services/test_backfill_service.py
+++ b/packages/stravapipe/tests/unit/application/backfill/services/test_backfill_service.py
@@ -151,6 +151,21 @@ def service_with_bq(
 # =============================================================================
 
 
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_rejects_non_positive_batch_size(
+    mock_strava_reader,
+    mock_uow_factory,
+    batch_size: int,
+):
+    """Direct service construction cannot silently disable batch processing."""
+    with pytest.raises(ValueError, match="batch_size must be greater than zero"):
+        BackfillService(
+            strava_reader=mock_strava_reader,
+            uow_factory=mock_uow_factory,
+            batch_size=batch_size,
+        )
+
+
 class TestBackfillUser:
     """Tests for BackfillService.backfill_user()."""
 
@@ -761,6 +776,58 @@ class TestProgressReporting:
             == "Progress reporter failed during year_complete for athlete 12345"
             for record in caplog.records
         )
+
+    def test_reporter_mutation_cannot_change_backfill_state(
+        self,
+        mock_strava_reader,
+        mock_uow_factory,
+        mock_progress,
+    ):
+        """Reporter payloads are snapshots, even when mutation precedes failure."""
+
+        def mutate_started(_athlete_id: str, reported_years: list[int]) -> None:
+            reported_years.clear()
+            raise RuntimeError("progress unavailable")
+
+        def mutate_year(_athlete_id: str, stats: YearStats) -> None:
+            stats.activities_found = 999
+            stats.pg_inserted = 999
+            raise RuntimeError("progress unavailable")
+
+        def mutate_completed(_athlete_id: str, result: BackfillResult) -> None:
+            result.years.clear()
+            result.year_stats.clear()
+            result.total_activities = 999
+            result.total_pg_inserted = 999
+            result.total_errors = 999
+            raise RuntimeError("progress unavailable")
+
+        mock_strava_reader.read_activities_by_year.side_effect = [
+            make_activities(2, year=2023),
+            make_activities(1, year=2024),
+        ]
+        mock_progress.report_started.side_effect = mutate_started
+        mock_progress.report_year_complete.side_effect = mutate_year
+        mock_progress.report_completed.side_effect = mutate_completed
+        service = BackfillService(
+            strava_reader=mock_strava_reader,
+            uow_factory=mock_uow_factory,
+            progress_reporter=mock_progress,
+        )
+
+        result = service.backfill_user("12345", years=[2024, 2023])
+
+        assert result.years == [2023, 2024]
+        assert [stats.activities_found for stats in result.year_stats] == [2, 1]
+        assert [stats.pg_inserted for stats in result.year_stats] == [2, 1]
+        assert result.total_activities == 3
+        assert result.total_pg_inserted == 3
+        assert result.total_errors == 0
+        assert result.success is True
+        assert mock_strava_reader.read_activities_by_year.call_args_list == [
+            call(2023),
+            call(2024),
+        ]
 
     def test_reports_completed_on_success(
         self,

--- a/packages/stravapipe/tests/unit/application/backfill/services/test_backfill_service.py
+++ b/packages/stravapipe/tests/unit/application/backfill/services/test_backfill_service.py
@@ -14,8 +14,11 @@ import pytest
 
 from stravapipe.adapters.gcp import ActivitiesWriter
 from stravapipe.application.backfill.service import (
+    BackfillResult,
     BackfillService,
+    PostgresWriteStats,
     ProgressReporter,
+    YearStats,
 )
 from stravapipe.domain.activity import MetaAthlete, SummaryMap, SummaryStravaActivity
 from stravapipe.ports.out.postgres import ActivityRepository
@@ -76,7 +79,10 @@ def make_activities(count: int, year: int = 2024) -> list[SummaryStravaActivity]
 @pytest.fixture
 def mock_activity_repo():
     """Mock activity repository with spec for interface compliance."""
-    return create_autospec(ActivityRepository, instance=True)
+    repository = create_autospec(ActivityRepository, instance=True)
+    repository.get_existing_ids.return_value = set()
+    repository.upsert.return_value = True
+    return repository
 
 
 @pytest.fixture
@@ -157,7 +163,6 @@ class TestBackfillUser:
         """Backfills activities for a single year."""
         activities = make_activities(3, year=2024)
         mock_strava_reader.read_activities_by_year.return_value = activities
-        mock_activity_repo.insert.return_value = True
 
         result = service.backfill_user("12345", years=[2024])
 
@@ -176,7 +181,7 @@ class TestBackfillUser:
     ):
         """Years are processed in sorted order."""
         mock_strava_reader.read_activities_by_year.return_value = make_activities(2)
-        mock_activity_repo.insert.return_value = True
+        mock_activity_repo.get_existing_ids.return_value = {1}
 
         result = service.backfill_user("12345", years=[2025, 2023, 2024])
 
@@ -187,6 +192,8 @@ class TestBackfillUser:
             call(2025),
         ]
         assert result.total_activities == 6  # 2 per year * 3 years
+        assert result.total_pg_inserted == 3
+        assert result.total_pg_updated == 3
 
     def test_handles_empty_year(
         self,
@@ -203,6 +210,7 @@ class TestBackfillUser:
         assert result.success is True
         assert len(result.year_stats) == 1
         assert result.year_stats[0].activities_found == 0
+        assert result.year_stats[0].duration_seconds >= 0
 
     def test_records_duration(
         self,
@@ -215,6 +223,22 @@ class TestBackfillUser:
         result = service.backfill_user("12345", years=[2024])
 
         assert result.duration_seconds >= 0
+
+    def test_empty_year_records_measured_duration(
+        self,
+        service: BackfillService,
+        mock_strava_reader,
+    ):
+        """Empty years report measured elapsed time instead of the default zero."""
+        mock_strava_reader.read_activities_by_year.return_value = []
+
+        with patch(
+            "stravapipe.application.backfill.service.time.monotonic",
+            side_effect=[10.0, 12.5],
+        ):
+            stats = service._backfill_year(2024)
+
+        assert stats.duration_seconds == 2.5
 
 
 # =============================================================================
@@ -240,7 +264,6 @@ class TestPostgresInsertion:
         )
         activities = make_activities(5, year=2024)
         mock_strava_reader.read_activities_by_year.return_value = activities
-        mock_activity_repo.insert.return_value = True
 
         result = service.backfill_user("12345", years=[2024])
 
@@ -248,24 +271,74 @@ class TestPostgresInsertion:
         assert mock_uow_factory.call_count == 3
         assert mock_uow.commit.call_count == 3
         assert result.total_pg_inserted == 5
+        assert mock_activity_repo.get_existing_ids.call_args_list == [
+            call([1, 2]),
+            call([3, 4]),
+            call([5]),
+        ]
 
-    def test_tracks_duplicates_as_skipped(
+    def test_classifies_existing_activities_as_updated(
         self,
         service: BackfillService,
         mock_strava_reader,
         mock_activity_repo,
     ):
-        """Duplicate activities (insert returns False) are tracked as skipped."""
+        """The batch pre-read classifies committed upserts as inserts or updates."""
         activities = make_activities(3, year=2024)
         mock_strava_reader.read_activities_by_year.return_value = activities
-        # First insert succeeds, second and third are duplicates
-        mock_activity_repo.insert.side_effect = [True, False, False]
+        mock_activity_repo.get_existing_ids.return_value = {2, 3}
 
         result = service.backfill_user("12345", years=[2024])
 
         assert result.total_pg_inserted == 1
-        assert result.year_stats[0].pg_skipped == 2
-        assert result.success is True  # Duplicates are not errors
+        assert result.total_pg_updated == 2
+        assert result.year_stats[0].pg_updated == 2
+        assert result.success is True
+        mock_activity_repo.get_existing_ids.assert_called_once_with([1, 2, 3])
+        assert mock_activity_repo.upsert.call_count == 3
+
+    def test_commit_failure_discards_batch_counts(
+        self,
+        service: BackfillService,
+        mock_strava_reader,
+        mock_activity_repo,
+        mock_uow,
+    ):
+        """A failed commit rolls back and classifies every activity as an error."""
+        activities = make_activities(3)
+        mock_strava_reader.read_activities_by_year.return_value = activities
+        mock_activity_repo.get_existing_ids.return_value = {2}
+        mock_uow.commit.side_effect = RuntimeError("commit failed")
+
+        result = service.backfill_user("12345", years=[2024])
+
+        year_stats = result.year_stats[0]
+        assert year_stats.pg_inserted == 0
+        assert year_stats.pg_updated == 0
+        assert year_stats.pg_errors == 3
+        assert (
+            year_stats.pg_inserted + year_stats.pg_updated + year_stats.pg_errors
+            == year_stats.activities_found
+        )
+
+    def test_false_upsert_fails_the_whole_transactional_batch(
+        self,
+        service: BackfillService,
+        mock_strava_reader,
+        mock_activity_repo,
+        mock_uow,
+    ):
+        """An unexpected false upsert cannot silently disappear from metrics."""
+        mock_strava_reader.read_activities_by_year.return_value = make_activities(2)
+        mock_activity_repo.upsert.side_effect = [True, False]
+
+        result = service.backfill_user("12345", years=[2024])
+
+        year_stats = result.year_stats[0]
+        assert year_stats.pg_inserted == 0
+        assert year_stats.pg_updated == 0
+        assert year_stats.pg_errors == 2
+        mock_uow.commit.assert_not_called()
 
     def test_batch_error_is_tracked(
         self,
@@ -298,7 +371,6 @@ class TestPostgresInsertion:
         uow2.__enter__.return_value = uow2
 
         factory = MagicMock(side_effect=[uow1, uow2])
-        mock_activity_repo.insert.return_value = True
 
         service = BackfillService(
             strava_reader=mock_strava_reader,
@@ -329,7 +401,6 @@ class TestBigQueryInsertion:
         """No BQ writes when bq_writer is None."""
         activities = make_activities(3, year=2024)
         mock_strava_reader.read_activities_by_year.return_value = activities
-        mock_activity_repo.insert.return_value = True
 
         result = service.backfill_user("12345", years=[2024])
 
@@ -345,7 +416,6 @@ class TestBigQueryInsertion:
         """BQ writes happen when writer is configured."""
         activities = make_activities(3, year=2024)
         mock_strava_reader.read_activities_by_year.return_value = activities
-        mock_activity_repo.insert.return_value = True
         mock_bq_writer.write_activities_batch.return_value = {
             "rows_affected": 3,
             "execution_time_ms": 100,
@@ -368,7 +438,6 @@ class TestBigQueryInsertion:
         """BQ errors are tracked without stopping PG writes."""
         activities = make_activities(3, year=2024)
         mock_strava_reader.read_activities_by_year.return_value = activities
-        mock_activity_repo.insert.return_value = True
         mock_bq_writer.write_activities_batch.side_effect = RuntimeError("BQ error")
 
         result = service_with_bq.backfill_user("12345", years=[2024])
@@ -415,7 +484,6 @@ class TestBigQueryRetry:
         """Each retryable exception class: 2 failures then success → no error."""
         activities = make_activities(3, year=2024)
         mock_strava_reader.read_activities_by_year.return_value = activities
-        mock_activity_repo.insert.return_value = True
         mock_bq_writer.write_activities_batch.side_effect = [
             exc,
             exc,
@@ -456,7 +524,6 @@ class TestBigQueryRetry:
         """Three transient failures: batch errored once; no 4th attempt."""
         activities = make_activities(3, year=2024)
         mock_strava_reader.read_activities_by_year.return_value = activities
-        mock_activity_repo.insert.return_value = True
         mock_bq_writer.write_activities_batch.side_effect = (
             gapi_exceptions.ServiceUnavailable("503")
         )
@@ -481,7 +548,6 @@ class TestBigQueryRetry:
         """InvalidArgument (schema drift) is not retried — fail once."""
         activities = make_activities(3, year=2024)
         mock_strava_reader.read_activities_by_year.return_value = activities
-        mock_activity_repo.insert.return_value = True
         mock_bq_writer.write_activities_batch.side_effect = (
             gapi_exceptions.InvalidArgument("schema mismatch")
         )
@@ -494,6 +560,119 @@ class TestBigQueryRetry:
         mock_sleep.assert_not_called()
         assert result.year_stats[0].bq_errors == 3
         assert result.success is False
+
+
+# =============================================================================
+# Tests: Metric Logging
+# =============================================================================
+
+
+class TestMetricLogging:
+    """Tests for the exact batch, year, and terminal metric contract."""
+
+    def test_logs_postgres_batch_metrics(
+        self,
+        service: BackfillService,
+        mock_activity_repo,
+        caplog,
+    ):
+        """A committed batch logs inserted, updated, and error counts."""
+        mock_activity_repo.get_existing_ids.return_value = {2, 3}
+
+        with caplog.at_level("INFO", logger="stravapipe.application.backfill.service"):
+            stats = service._insert_to_postgres(make_activities(3))
+
+        assert stats == PostgresWriteStats(inserted=1, updated=2, errors=0)
+        assert [
+            record.getMessage()
+            for record in caplog.records
+            if record.getMessage().startswith("PG batch")
+        ] == ["PG batch 1/1: 1 inserted, 2 updated, 0 errors"]
+
+    def test_logs_year_metrics(
+        self,
+        service: BackfillService,
+        mock_strava_reader,
+        caplog,
+    ):
+        """The year summary reports the same PostgreSQL metric contract."""
+        mock_strava_reader.read_activities_by_year.return_value = make_activities(3)
+
+        with (
+            patch.object(
+                service,
+                "_insert_to_postgres",
+                return_value=PostgresWriteStats(inserted=2, updated=1),
+            ),
+            patch(
+                "stravapipe.application.backfill.service.time.monotonic",
+                side_effect=[10.0, 12.0],
+            ),
+            caplog.at_level("INFO", logger="stravapipe.application.backfill.service"),
+        ):
+            service._backfill_year(2024)
+
+        assert [
+            record.getMessage()
+            for record in caplog.records
+            if record.getMessage().startswith("Year 2024 complete")
+        ] == [
+            "Year 2024 complete in 2.0s: "
+            "PG(2 inserted, 1 updated, 0 errors), BQ(0 inserted, 0 errors)"
+        ]
+
+    @pytest.mark.parametrize(
+        ("pg_errors", "level", "prefix"),
+        [
+            (0, "INFO", "Backfill completed for athlete"),
+            (1, "WARNING", "Backfill completed with errors for athlete"),
+        ],
+    )
+    def test_logs_terminal_metrics(
+        self,
+        service: BackfillService,
+        caplog,
+        pg_errors: int,
+        level: str,
+        prefix: str,
+    ):
+        """Success and failure summaries expose the same terminal fields."""
+        stats = YearStats(
+            year=2024,
+            activities_found=4,
+            pg_inserted=2,
+            pg_updated=1,
+            pg_errors=pg_errors,
+            bq_inserted=4,
+        )
+
+        with (
+            patch.object(service, "_backfill_year", return_value=stats),
+            patch(
+                "stravapipe.application.backfill.service.time.monotonic",
+                side_effect=[10.0, 15.0],
+            ),
+            caplog.at_level(level, logger="stravapipe.application.backfill.service"),
+        ):
+            service.backfill_user("12345", years=[2024])
+
+        terminal = [
+            record.getMessage()
+            for record in caplog.records
+            if record.getMessage().startswith(prefix)
+        ]
+        if pg_errors == 0:
+            assert terminal == [
+                "Backfill completed for athlete 12345: 4 activities across 1 year "
+                "(PG: 2 inserted, 1 updated; "
+                "BQ: 4 inserted; errors: 0) in 5.0s"
+            ]
+        else:
+            assert terminal == [
+                "Backfill completed with errors for athlete 12345: 4 activities "
+                "across 1 year (PG: 2 inserted, 1 updated; "
+                "BQ: 4 inserted; errors: 1) in 5.0s"
+            ]
 
 
 # =============================================================================
@@ -534,7 +713,6 @@ class TestProgressReporting:
             make_activities(5, year=2023),
             make_activities(3, year=2024),
         ]
-        mock_activity_repo.insert.return_value = True
 
         service = BackfillService(
             strava_reader=mock_strava_reader,
@@ -542,12 +720,47 @@ class TestProgressReporting:
             progress_reporter=mock_progress,
         )
 
-        service.backfill_user("12345", years=[2023, 2024])
+        result = service.backfill_user("12345", years=[2023, 2024])
 
         assert mock_progress.report_year_complete.call_args_list == [
-            call("12345", 2023, 5),
-            call("12345", 2024, 3),
+            call("12345", result.year_stats[0]),
+            call("12345", result.year_stats[1]),
         ]
+        assert [stats.activities_found for stats in result.year_stats] == [5, 3]
+
+    def test_reporter_failure_does_not_corrupt_successful_year(
+        self,
+        mock_strava_reader,
+        mock_uow_factory,
+        mock_activity_repo,
+        mock_progress,
+        caplog,
+    ):
+        """A control-plane failure cannot duplicate or fail committed data stats."""
+        mock_strava_reader.read_activities_by_year.return_value = make_activities(2)
+        mock_activity_repo.get_existing_ids.return_value = {2}
+        mock_progress.report_year_complete.side_effect = RuntimeError(
+            "progress unavailable"
+        )
+        service = BackfillService(
+            strava_reader=mock_strava_reader,
+            uow_factory=mock_uow_factory,
+            progress_reporter=mock_progress,
+        )
+
+        with caplog.at_level("ERROR", logger="stravapipe.application.backfill.service"):
+            result = service.backfill_user("12345", years=[2024])
+
+        assert result.success is True
+        assert len(result.year_stats) == 1
+        assert result.total_pg_inserted == 1
+        assert result.total_pg_updated == 1
+        mock_progress.report_completed.assert_called_once_with("12345", result)
+        assert any(
+            record.getMessage()
+            == "Progress reporter failed during year_complete for athlete 12345"
+            for record in caplog.records
+        )
 
     def test_reports_completed_on_success(
         self,
@@ -621,7 +834,6 @@ class TestErrorResilience:
             RuntimeError("Strava API down"),  # 2023 fails
             make_activities(3, year=2024),  # 2024 succeeds
         ]
-        mock_activity_repo.insert.return_value = True
         service = BackfillService(
             strava_reader=mock_strava_reader,
             uow_factory=mock_uow_factory,
@@ -645,14 +857,10 @@ class TestBackfillResult:
 
     def test_success_when_no_errors(self):
         """Result is successful when total_errors is 0."""
-        from stravapipe.application.backfill.service import BackfillResult
-
         result = BackfillResult(athlete_id="123", total_errors=0)
         assert result.success is True
 
     def test_not_success_when_errors(self):
         """Result is not successful when there are errors."""
-        from stravapipe.application.backfill.service import BackfillResult
-
         result = BackfillResult(athlete_id="123", total_errors=1)
         assert result.success is False

--- a/packages/stravapipe/tests/unit/cloudrun/test_backfill_job.py
+++ b/packages/stravapipe/tests/unit/cloudrun/test_backfill_job.py
@@ -1,0 +1,50 @@
+"""Unit tests for the backfill Cloud Run Job terminal summary."""
+
+from unittest.mock import patch
+
+import pytest
+
+from stravapipe.application.backfill import BackfillResult
+from stravapipe.cloudrun.backfill_job import _log_result
+
+
+@pytest.mark.parametrize(
+    ("total_errors", "expected_exit_code", "log_method", "status"),
+    [
+        (0, 0, "info", "succeeded"),
+        (2, 1, "error", "completed with errors"),
+    ],
+)
+def test_log_result_uses_consistent_terminal_metrics(
+    total_errors: int,
+    expected_exit_code: int,
+    log_method: str,
+    status: str,
+):
+    """Success and failure expose the same inserted/updated/error fields."""
+    result = BackfillResult(
+        athlete_id="12345",
+        total_activities=7,
+        total_pg_inserted=3,
+        total_pg_updated=4,
+        total_bq_inserted=7,
+        total_errors=total_errors,
+        duration_seconds=12.5,
+    )
+
+    with patch("stravapipe.cloudrun.backfill_job.logger") as mock_logger:
+        exit_code = _log_result(result)
+
+    assert exit_code == expected_exit_code
+    log = getattr(mock_logger, log_method)
+    log.assert_called_once_with(
+        "Backfill %s: %d activities "
+        "(PG: %d inserted, %d updated; BQ: %d inserted; errors: %d) in %.1fs",
+        status,
+        7,
+        3,
+        4,
+        7,
+        total_errors,
+        12.5,
+    )

--- a/packages/stravapipe/tests/unit/config/test_backfill.py
+++ b/packages/stravapipe/tests/unit/config/test_backfill.py
@@ -1,0 +1,20 @@
+"""Unit tests for backfill configuration."""
+
+from pydantic import ValidationError
+import pytest
+
+from stravapipe.config.backfill import BackfillConfig
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_rejects_non_positive_batch_size(batch_size: int):
+    """Deployment configuration cannot silently disable batch processing."""
+    with pytest.raises(ValidationError, match="greater than 0"):
+        BackfillConfig(
+            athlete_id="12345",
+            gcp_project_id="test-project",
+            strava_client_id="123",
+            strava_client_secret="secret",
+            postgres_connection_string="postgresql+psycopg://test",
+            batch_size=batch_size,
+        )


### PR DESCRIPTION
- classify PostgreSQL writes as inserted or updated
- preserve transaction-aware counts when batches fail
- add resilient progress and terminal reporting
- cover backfill metrics, failures, and logging with tests