### PR TITLE
fix(dispatcher): respond 200 to Strava webhooks so events aren't retried

### DIFF
--- a/packages/dispatcher/adapters/http/benchmark_test.go
+++ b/packages/dispatcher/adapters/http/benchmark_test.go
@@ -54,7 +54,7 @@ func BenchmarkHandler_ServeHTTP_ValidWebhook(b *testing.B) {
 
 		router.ServeHTTP(rr, req)
 
-		if rr.Code != http.StatusCreated {
+		if rr.Code != http.StatusOK {
 			b.Fatalf("unexpected status: %d", rr.Code)
 		}
 	}
@@ -119,8 +119,8 @@ func BenchmarkHandler_ServeHTTP_Concurrent(b *testing.B) {
 
 			router.ServeHTTP(rr, req)
 
-			if rr.Code != http.StatusCreated {
-				b.Errorf("unexpected status in concurrent test: got %d, want %d", rr.Code, http.StatusCreated)
+			if rr.Code != http.StatusOK {
+				b.Errorf("unexpected status in concurrent test: got %d, want %d", rr.Code, http.StatusOK)
 			}
 		}
 	})

--- a/packages/dispatcher/adapters/http/handler.go
+++ b/packages/dispatcher/adapters/http/handler.go
@@ -855,14 +855,21 @@ type webhookResponse struct {
 	Action  string `json:"action"`
 }
 
-// writeSuccess returns 201 Created when a message is published to Pub/Sub.
+// writeSuccess returns 200 OK when a message is published to Pub/Sub.
 //
-// NOTE: Strava docs specify "200 OK" for acknowledgment. In practice Strava
-// accepts any 2xx, but if retries are observed this should be changed to 200.
-// We use 201 to distinguish "published to Pub/Sub" from "acknowledged but ignored".
+// This used to return 201 Created, to distinguish "published to Pub/Sub" from
+// "acknowledged but ignored", on the assumption that Strava accepts any 2xx.
+// It does not: Strava's spec says 200, and anything else is treated as a failed
+// delivery. Prod request logs settled it — every 201 was redelivered three
+// times at 120s intervals despite sub-second latency, while a 200 was accepted
+// on the spot and never redelivered. Three deliveries meant triple the Strava
+// API calls and triple the downstream writes for every event.
+//
+// The published-vs-acknowledged distinction lives in the response body's
+// `action` field, which is where a caller that cares can still read it.
 func (h *Handler) writeSuccess(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", contentTypeJSON)
-	w.WriteHeader(http.StatusCreated)
+	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(webhookResponse{Success: true, Action: webhookPublished}); err != nil {
 		h.logger.Error("Failed to encode success response", "error", err)
 	}

--- a/packages/dispatcher/adapters/http/handler_test.go
+++ b/packages/dispatcher/adapters/http/handler_test.go
@@ -224,7 +224,7 @@ func TestHandler_HandleEvent(t *testing.T) {
 			payload:        validPayload,
 			mockSubID:      testSubscriptionID,
 			stravaResult:   []byte(`{"id":12345,"name":"Morning Run"}`),
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 			expectedBody:   "published",
 		},
 		{
@@ -241,7 +241,7 @@ func TestHandler_HandleEvent(t *testing.T) {
 				Updates:        map[string]any{"title": "Evening Run"},
 			},
 			mockSubID:      testSubscriptionID,
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 			expectedBody:   "published",
 		},
 		{
@@ -257,7 +257,7 @@ func TestHandler_HandleEvent(t *testing.T) {
 				SubscriptionID: testSubscriptionID,
 			},
 			mockSubID:      testSubscriptionID,
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 			expectedBody:   "published",
 		},
 		{
@@ -379,7 +379,7 @@ func TestHandler_HandleEvent(t *testing.T) {
 			payload:        validPayload,
 			mockSubID:      testSubscriptionID,
 			stravaErr:      ports.ErrActivityNotFound,
-			expectedStatus: http.StatusCreated,
+			expectedStatus: http.StatusOK,
 			expectedBody:   "published",
 		},
 		{
@@ -546,7 +546,7 @@ func runHandleEventTest(t *testing.T, tt *handleEventTestCase) {
 	}
 
 	// Verify published enriched events for successful publishes
-	if tt.expectedStatus == http.StatusCreated && len(mockPublisher.Published) > 0 {
+	if tt.expectedStatus == http.StatusOK && len(mockPublisher.Published) > 0 {
 		enriched := mockPublisher.Published[0]
 		if enriched.Event == nil {
 			t.Fatal("published enriched event has nil Event")
@@ -897,7 +897,7 @@ func TestHandler_OwnerCheck_CounterLabels(t *testing.T) {
 			name:         "allowed",
 			allowlist:    portstest.NewAllowAllMockAllowlist(),
 			wantResult:   "allowed",
-			wantStatus:   http.StatusCreated,
+			wantStatus:   http.StatusOK,
 			payloadBytes: validBody,
 		},
 		{
@@ -1025,7 +1025,7 @@ func TestHandler_EnrichmentBehavior_Create(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusCreated {
+	if w.Code != http.StatusOK {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
@@ -1075,7 +1075,7 @@ func TestHandler_EnrichmentBehavior_Update_TitleOnly(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusCreated {
+	if w.Code != http.StatusOK {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
@@ -1119,7 +1119,7 @@ func TestHandler_EnrichmentBehavior_Update_TypeChange(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusCreated {
+	if w.Code != http.StatusOK {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 
@@ -1166,7 +1166,7 @@ func TestHandler_EnrichmentBehavior_Update_TypeChange_ActivityGone(t *testing.T)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusCreated {
+	if w.Code != http.StatusOK {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 	if len(mockPublisher.Published) != 1 {
@@ -1256,7 +1256,7 @@ func TestHandler_EnrichmentBehavior_Delete(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	if w.Code != http.StatusCreated {
+	if w.Code != http.StatusOK {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 

--- a/packages/dispatcher/adapters/http/integration_test.go
+++ b/packages/dispatcher/adapters/http/integration_test.go
@@ -93,7 +93,7 @@ func TestIntegration_ConcurrentRequests(t *testing.T) {
 	statusCounts := make(map[int]int)
 	for status := range results {
 		statusCounts[status]++
-		if status == http.StatusCreated {
+		if status == http.StatusOK {
 			successCount++
 		}
 	}
@@ -144,7 +144,7 @@ func TestIntegration_SecretReload(t *testing.T) {
 	rr1 := httptest.NewRecorder()
 	router.ServeHTTP(rr1, req1)
 
-	if rr1.Code != http.StatusCreated {
+	if rr1.Code != http.StatusOK {
 		t.Errorf("first request: expected 201, got %d (body: %s)", rr1.Code, rr1.Body.String())
 	}
 
@@ -183,7 +183,7 @@ func TestIntegration_SecretReload(t *testing.T) {
 	rr3 := httptest.NewRecorder()
 	router.ServeHTTP(rr3, req3)
 
-	if rr3.Code != http.StatusCreated {
+	if rr3.Code != http.StatusOK {
 		t.Errorf("expected 201 with new secret, got %d (body: %s)", rr3.Code, rr3.Body.String())
 	}
 }

--- a/packages/dispatcher/adapters/http/row_publish_test.go
+++ b/packages/dispatcher/adapters/http/row_publish_test.go
@@ -158,7 +158,7 @@ func TestActivityRowPublish_ChangeTypes(t *testing.T) {
 			}
 
 			w := serveRowPublishWebhook(t, setup, tt.payload)
-			if w.Code != http.StatusCreated && w.Code != http.StatusOK {
+			if w.Code != http.StatusOK {
 				t.Fatalf("status = %d, want a success (body: %s)", w.Code, w.Body.String())
 			}
 
@@ -229,8 +229,8 @@ func TestActivityRowPublish_DisabledPublishesNothing(t *testing.T) {
 
 	w := serveRowPublishWebhook(t, setup, activityWebhook("create"))
 
-	if w.Code != http.StatusCreated {
-		t.Errorf("status = %d, want %d (body: %s)", w.Code, http.StatusCreated, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (body: %s)", w.Code, http.StatusOK, w.Body.String())
 	}
 	if got := primary.PublishedCount(); got != 1 {
 		t.Errorf("primary published %d events, want 1", got)
@@ -283,9 +283,9 @@ func TestActivityRowPublish_FailureDoesNotAffectWebhook(t *testing.T) {
 
 			w := serveRowPublishWebhook(t, setup, activityWebhook("create"))
 
-			if w.Code != http.StatusCreated {
+			if w.Code != http.StatusOK {
 				t.Errorf("status = %d, want %d — a row-publish failure must not fail the webhook (body: %s)",
-					w.Code, http.StatusCreated, w.Body.String())
+					w.Code, http.StatusOK, w.Body.String())
 			}
 			if got := primary.PublishedCount(); got != 1 {
 				t.Errorf("primary published %d events, want 1 — the primary path must be untouched", got)


### PR DESCRIPTION
Strava's webhook spec requires the callback to "acknowledge the POST of each new event with a status code of 200 OK within two seconds", and retries "up to a total of three attempts) if a 200 is not returned". writeSuccess returned 201 Created, so every published event was delivered three times.

Confirmed in prod request logs: each 201 was redelivered three times at 120s intervals despite 0.04-0.30s latency, while the only 200 responses (cold starts that overran the 2s budget on their first attempt) were accepted on the retry and never delivered again.

Each duplicate ran the full pipeline, so this was triple the Strava API calls, Pub/Sub messages, PostgreSQL upserts and BigQuery writes per event. The event-time fence did not suppress them: Strava re-stamps event_time on each attempt, so every retry looked legitimately newer.

The published-vs-acknowledged distinction 201 was carrying remains available in the response body's `action` field.