### PR TITLE
perf(dispatcher): poll the startup probe every second so cold webhook…

### DIFF
--- a/terraform/modules/desirelines/cloud_run.tf
+++ b/terraform/modules/desirelines/cloud_run.tf
@@ -151,13 +151,21 @@ resource "google_cloud_run_v2_service" "dispatcher" {
         value = google_pubsub_topic.activity_rows.name
       }
 
+      # Cloud Run serves no traffic until this probe passes, so the poll period
+      # is a floor on cold-start latency — and Strava retries any webhook not
+      # answered within 2s. The app binds its port in ~290ms, so a 1s period
+      # catches it on the second poll.
+      #
+      # period_seconds and failure_threshold multiply into the total startup
+      # budget (~10s here). Change them together: shrinking the period alone
+      # starts killing containers whose image pull runs long.
       startup_probe {
         http_get {
           path = "/health"
         }
         initial_delay_seconds = 0
-        period_seconds        = 3
-        failure_threshold     = 3
+        period_seconds        = 1
+        failure_threshold     = 10
       }
 
       # Mount Strava Webhook secrets as atomic volumes


### PR DESCRIPTION
…s fit Strava's budget

Cloud Run withholds all traffic from an instance until its startup probe passes. The dispatcher binds its port ~290ms after the container starts — just late enough to miss the first poll — so at a 3s period the next poll was a full 3s later, and a cold webhook sat queued behind a container that had been listening the whole time.

Measured over 30 days: 28.2% of webhook POSTs (50 of 177) exceeded the two seconds Strava allows before it treats the delivery as failed and retries, and every one of those events was processed twice. Tracing one such request end to end: 0.53s provisioning, 0.29s app boot, then 2.98s idle waiting for the probe — 78% of a 3.8s cold start spent doing nothing. The slow band's hard floor at 3.28s is one probe period plus boot, which is what pointed at the cadence rather than at startup itself.

failure_threshold moves from 3 to 10 deliberately. The two values multiply into the total startup budget, so dropping the period alone would shrink it from 9s to 3s and start killing containers whose image pull ran long — strictly worse than the bug. 1 x 10 holds the budget at ~10s.