### PR TITLE
fix(dispatcher): bound the activity-row re-fetch to 1s

### DIFF
--- a/packages/dispatcher/adapters/http/handler.go
+++ b/packages/dispatcher/adapters/http/handler.go
@@ -123,6 +123,19 @@ const maxChallengeLength = 256
 // staying well under Cloud Run's default 60s request timeout.
 const handleEventDeadline = 10 * time.Second
 
+// DefaultRowRefetchTimeout bounds the Strava re-fetch the activity-row publish
+// makes for a metadata-only update. It is deliberately far tighter than
+// handleEventDeadline: that budget exists for work the webhook depends on, and
+// this call is best-effort for a table nothing reads. Left on the full budget, a
+// slow Strava would spend seconds here after the webhook was already handled and
+// push the response past the 2s Strava allows before redelivering.
+//
+// 1s against an observed ~288ms mean for an activity fetch — roughly 3× headroom
+// for a normal call, while cutting off the pathological one. It also admits only
+// a single attempt, since the client's retry backoff starts at 1s; retries belong
+// on the primary path, not here.
+const DefaultRowRefetchTimeout = 1 * time.Second
+
 // Handler orchestrates the webhook processing.
 type Handler struct {
 	secretProvider     ports.SecretProvider
@@ -138,6 +151,7 @@ type Handler struct {
 	webhookCounter     metric.Int64Counter
 	ownerCheckCounter  metric.Int64Counter
 	rowPublishCounter  metric.Int64Counter
+	rowRefetchTimeout  time.Duration
 	httpHistogram      metric.Float64Histogram
 	tracer             trace.Tracer
 }
@@ -156,6 +170,9 @@ type HandlerConfig struct {
 	// RowPublishCounter counts the outcome of every row publish attempt
 	// (published / skipped / error). Optional; nil disables the metric.
 	RowPublishCounter metric.Int64Counter
+	// RowRefetchTimeout bounds the Strava re-fetch made for a metadata-only
+	// update. Zero takes DefaultRowRefetchTimeout.
+	RowRefetchTimeout time.Duration
 	// Tracer is used for handler-level spans (e.g. allowlist check). If nil
 	// at construction time the handler falls back to a no-op tracer; spans
 	// inside the handler simply don't get emitted.
@@ -170,6 +187,10 @@ func NewHandler(publisher, deauthPublisher ports.Publisher, secretProvider ports
 	maxBodySize := config.DefaultMaxRequestBodySize
 	if cfg.MaxRequestBodySize > 0 {
 		maxBodySize = cfg.MaxRequestBodySize
+	}
+	rowRefetchTimeout := DefaultRowRefetchTimeout
+	if cfg.RowRefetchTimeout > 0 {
+		rowRefetchTimeout = cfg.RowRefetchTimeout
 	}
 	tracer := cfg.Tracer
 	if tracer == nil {
@@ -193,6 +214,7 @@ func NewHandler(publisher, deauthPublisher ports.Publisher, secretProvider ports
 		webhookCounter:     cfg.WebhookCounter,
 		ownerCheckCounter:  cfg.OwnerCheckCounter,
 		rowPublishCounter:  cfg.RowPublishCounter,
+		rowRefetchTimeout:  rowRefetchTimeout,
 		httpHistogram:      cfg.HTTPHistogram,
 		tracer:             tracer,
 	}
@@ -751,6 +773,9 @@ func (h *Handler) buildActivityRow(ctx context.Context, enriched *generated.Enri
 // webhook is already handled, and a missed row self-corrects on the next event
 // carrying a payload.
 func (h *Handler) fetchActivityForRow(ctx context.Context, webhook *generated.WebhookEvent, correlationID string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, h.rowRefetchTimeout)
+	defer cancel()
+
 	rawActivity, err := h.stravaClient.FetchActivity(ctx, webhook.OwnerId, webhook.ObjectId)
 	if err != nil {
 		h.logger.Warn("Activity re-fetch for row publish failed, skipping row",

--- a/packages/dispatcher/adapters/http/row_publish_test.go
+++ b/packages/dispatcher/adapters/http/row_publish_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/andy-esch/desirelines/packages/dispatcher/adapters/bqrow"
 	webhookproto "github.com/andy-esch/desirelines/packages/dispatcher/adapters/proto"
@@ -28,6 +29,9 @@ type rowPublishSetup struct {
 	rowCounter   *sdkmetric.ManualReader
 	primary      *portstest.MockPublisher
 	strava       *portstest.MockStravaClient
+	// refetchTimeout overrides DefaultRowRefetchTimeout so a timeout test does
+	// not have to wait out the real budget.
+	refetchTimeout time.Duration
 }
 
 // serveRowPublishWebhook runs one webhook through a handler wired for the
@@ -35,7 +39,7 @@ type rowPublishSetup struct {
 func serveRowPublishWebhook(t *testing.T, setup *rowPublishSetup, payload webhookproto.StravaWebhookJSON) *httptest.ResponseRecorder {
 	t.Helper()
 
-	cfg := &HandlerConfig{RowPublisher: setup.rowPublisher}
+	cfg := &HandlerConfig{RowPublisher: setup.rowPublisher, RowRefetchTimeout: setup.refetchTimeout}
 	if setup.rowCounter != nil {
 		provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(setup.rowCounter))
 		counter, err := provider.Meter("test").Int64Counter("desirelines.io/bigquery/row_publish")
@@ -423,4 +427,72 @@ func rowPublishLabels(rm metricdata.ResourceMetrics) []rowPublishLabel {
 		}
 	}
 	return out
+}
+
+// The re-fetch runs after the webhook has already been handled, on behalf of a
+// table nothing reads. It must not be able to spend the request's remaining
+// budget: Strava redelivers anything it does not get answered inside 2s, so a
+// slow fetch here would turn every rename into a duplicate delivery.
+func TestActivityRowPublish_RefetchIsBounded(t *testing.T) {
+	metadataUpdate := func() webhookproto.StravaWebhookJSON {
+		p := activityWebhook("update")
+		p.Updates = map[string]any{"title": "New name"}
+		return p
+	}
+
+	t.Run("fetch gets its own deadline, not the request budget", func(t *testing.T) {
+		strava := &portstest.MockStravaClient{FetchResult: rowPublishTestActivity}
+		setup := &rowPublishSetup{
+			rowPublisher: &portstest.MockRawPublisher{},
+			primary:      &portstest.MockPublisher{},
+			strava:       strava,
+		}
+
+		start := time.Now()
+		serveRowPublishWebhook(t, setup, metadataUpdate())
+
+		deadline, ok := strava.LastFetchDeadline()
+		if !ok {
+			t.Fatal("re-fetch ran with no deadline — it inherited the full request budget")
+		}
+		budget := deadline.Sub(start)
+		if budget > DefaultRowRefetchTimeout+250*time.Millisecond {
+			t.Errorf("re-fetch budget = %v, want ~%v", budget, DefaultRowRefetchTimeout)
+		}
+		if budget >= handleEventDeadline {
+			t.Errorf("re-fetch budget = %v, must be well under handleEventDeadline %v", budget, handleEventDeadline)
+		}
+	})
+
+	t.Run("a slow Strava is cut off and does not delay the response", func(t *testing.T) {
+		primary := &portstest.MockPublisher{}
+		rowPublisher := &portstest.MockRawPublisher{}
+		setup := &rowPublishSetup{
+			rowPublisher: rowPublisher,
+			primary:      primary,
+			// Far slower than the budget below, so the timeout decides.
+			strava: &portstest.MockStravaClient{
+				FetchResult: rowPublishTestActivity,
+				FetchDelay:  5 * time.Second,
+			},
+			refetchTimeout: 50 * time.Millisecond,
+		}
+
+		start := time.Now()
+		w := serveRowPublishWebhook(t, setup, metadataUpdate())
+		elapsed := time.Since(start)
+
+		if elapsed > time.Second {
+			t.Errorf("webhook took %v — the re-fetch was not cut off", elapsed)
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+		}
+		if got := primary.PublishedCount(); got != 1 {
+			t.Errorf("primary published %d events, want 1", got)
+		}
+		if got := rowPublisher.PublishedCount(); got != 0 {
+			t.Errorf("published %d rows, want 0 — a timed-out fetch has no row to send", got)
+		}
+	})
 }

--- a/packages/dispatcher/ports/portstest/mocks.go
+++ b/packages/dispatcher/ports/portstest/mocks.go
@@ -10,6 +10,7 @@ package portstest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -141,19 +142,50 @@ type MockStravaClient struct {
 	FetchResult []byte
 	// FetchErr is the error to return. Set during test setup.
 	FetchErr error
+	// FetchDelay simulates a slow Strava. The fetch waits this long before
+	// returning, but yields early if the caller's context expires first — so a
+	// delay longer than the caller's deadline exercises the timeout path.
+	FetchDelay time.Duration
 	// FetchedIDs tracks which activity IDs were fetched.
 	FetchedIDs []int64
 	// FetchedOwnerIDs tracks which owner IDs were passed.
 	FetchedOwnerIDs []int64
+	// FetchDeadlines records the deadline on each call's context, so a test can
+	// assert the caller bounded the fetch rather than handing over its own
+	// budget. Zero time means the context carried no deadline.
+	FetchDeadlines []time.Time
 }
 
 // FetchActivity implements the StravaClient interface.
-func (m *MockStravaClient) FetchActivity(_ context.Context, ownerID, activityID int64) ([]byte, error) {
+func (m *MockStravaClient) FetchActivity(ctx context.Context, ownerID, activityID int64) ([]byte, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.FetchedOwnerIDs = append(m.FetchedOwnerIDs, ownerID)
 	m.FetchedIDs = append(m.FetchedIDs, activityID)
-	return m.FetchResult, m.FetchErr
+	deadline, _ := ctx.Deadline()
+	m.FetchDeadlines = append(m.FetchDeadlines, deadline)
+	delay, result, err := m.FetchDelay, m.FetchResult, m.FetchErr
+	m.mu.Unlock()
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("mock strava fetch: %w", ctx.Err())
+		}
+	}
+	return result, err
+}
+
+// LastFetchDeadline returns the deadline seen by the most recent fetch, and
+// whether one was set.
+func (m *MockStravaClient) LastFetchDeadline() (time.Time, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.FetchDeadlines) == 0 {
+		return time.Time{}, false
+	}
+	d := m.FetchDeadlines[len(m.FetchDeadlines)-1]
+	return d, !d.IsZero()
 }
 
 // FetchedCount returns the number of fetch calls made.


### PR DESCRIPTION
The re-fetch made for a metadata-only update inherited handleEventDeadline — the full 10s request budget — plus the Strava client's retry ladder. A slow Strava could therefore spend seconds inside a best-effort block that runs after the webhook has already been handled, pushing the response past the 2s Strava allows before it redelivers.

The isolation around this path protects correctness: a row-publish failure cannot fail the webhook or the primary publish. It did not protect latency.

1s, against an observed 288ms mean across 496 activity fetches over 7 days — roughly 3x headroom for a normal call while cutting off the pathological one. It also admits a single attempt, since the client's retry backoff starts at 1s; retries belong on the primary path. A timed-out fetch records result="error", detail="refetch" and publishes nothing, which the existing classification already distinguishes from an activity that is genuinely gone.

Overridable via HandlerConfig, mirroring MaxRequestBodySize, so the timeout test does not have to wait out the real budget.