### PR TITLE
fix(dispatcher): send photos.primary.urls as JSON text, and retain the DLQ

### DIFF
--- a/packages/dispatcher/adapters/bqrow/row.go
+++ b/packages/dispatcher/adapters/bqrow/row.go
@@ -109,9 +109,16 @@ func normalize(row map[string]any) {
 		row["workout_type"] = n.String()
 	}
 
-	// photos.primary.urls is a JSON column and a REQUIRED field, so a primary
-	// photo whose urls are empty or missing would fail the whole row. Such a
-	// photo carries nothing anyway; drop it and keep the rest of the activity.
+	// photos.primary.urls is a JSON column, and the subscription wants JSON
+	// *text* for one — not the nested object Strava sends. Passing the object
+	// through rejects the entire message with invalid_argument, so every
+	// activity that has a photo silently dead-letters while photo-less ones
+	// succeed. BigQuery parses the text back into a JSON object on arrival, so
+	// the stored shape is the same either way; only the wire form differs.
+	//
+	// The field is also REQUIRED, so a primary photo with no usable urls would
+	// fail the row regardless. Such a photo carries nothing — drop it and keep
+	// the rest of the activity.
 	photos, ok := row["photos"].(map[string]any)
 	if !ok {
 		return
@@ -120,22 +127,38 @@ func normalize(row map[string]any) {
 	if !ok {
 		return
 	}
-	if !hasPhotoURLs(primary["urls"]) {
+	encoded, ok := encodePhotoURLs(primary["urls"])
+	if !ok {
 		photos["primary"] = nil
+		return
 	}
+	primary["urls"] = encoded
 }
 
-// hasPhotoURLs reports whether a photos.primary.urls value is worth sending.
-// The empty string is called out explicitly: it is what an over-eager
-// serializer produces for "no urls", and BigQuery stores it as an empty JSON
-// string rather than the NULL the caller meant.
-func hasPhotoURLs(urls any) bool {
+// encodePhotoURLs renders a photos.primary.urls value as the JSON text the
+// destination column expects. Reports false when there is nothing worth
+// sending, which the caller turns into a dropped primary photo rather than a
+// null in a REQUIRED field.
+//
+// A value that is already a string is passed through: it is either JSON text
+// from an earlier encoding, or the empty string that stands for "no urls".
+func encodePhotoURLs(urls any) (string, bool) {
 	switch v := urls.(type) {
 	case map[string]any:
-		return len(v) > 0
+		if len(v) == 0 {
+			return "", false
+		}
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			// Values came from decoding Strava's JSON, so they re-encode; a
+			// failure here means something unexpected, and dropping the photo
+			// is better than failing the whole row.
+			return "", false
+		}
+		return string(encoded), true
 	case string:
-		return v != ""
+		return v, v != ""
 	default:
-		return false
+		return "", false
 	}
 }

--- a/packages/dispatcher/adapters/bqrow/row_test.go
+++ b/packages/dispatcher/adapters/bqrow/row_test.go
@@ -225,7 +225,7 @@ func TestUpsert_PhotoPrimaryURLs(t *testing.T) {
 		wantPrimary bool
 	}{
 		{
-			name:        "urls object is kept",
+			name:        "urls object becomes JSON text",
 			raw:         `{"id": 1, "photos": {"count": 1, "primary": {"unique_id": "u", "urls": {"100": "https://example.test/a.jpg"}}}}`,
 			wantPrimary: true,
 		},
@@ -274,8 +274,17 @@ func TestUpsert_PhotoPrimaryURLs(t *testing.T) {
 				}
 				return
 			}
-			if _, isObject := primary["urls"].(map[string]any); !isObject {
-				t.Errorf("photos.primary.urls = %#v, want the urls object unchanged", primary["urls"])
+			encoded, isString := primary["urls"].(string)
+			if !isString {
+				t.Fatalf("photos.primary.urls = %#v, want JSON text (a string), not a nested object", primary["urls"])
+			}
+			// The text must still parse back to what Strava sent.
+			var decoded map[string]string
+			if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+				t.Fatalf("photos.primary.urls is not valid JSON text: %v (%q)", err, encoded)
+			}
+			if decoded["100"] != "https://example.test/a.jpg" {
+				t.Errorf("urls round-tripped to %#v, want the original entries", decoded)
 			}
 		})
 	}

--- a/terraform/modules/desirelines/bigquery_subscription.tf
+++ b/terraform/modules/desirelines/bigquery_subscription.tf
@@ -67,6 +67,15 @@ resource "google_pubsub_topic" "activity_rows_dead_letter" {
   name   = "${var.project_name}-activity-rows-dlq-${var.environment}"
   labels = local.common_labels
 
+  # Retention matters more here than on any other topic. Clearing this DLQ is
+  # how its CRITICAL alert is silenced, and the only record of *why* BigQuery
+  # rejected a row is the CloudPubSubDeadLetterSourceDeliveryErrorMessage
+  # attribute on the message itself. Without topic retention the inspection
+  # subscription cannot seek backwards, so silencing the alert destroys the
+  # diagnosis — which has already cost two investigations. Matches the
+  # production dead_letter topic's 14 days.
+  message_retention_duration = "1209600s" # 14 days
+
   depends_on = [google_project_service.required_apis]
 }
 


### PR DESCRIPTION


The CDC subscription wants JSON *text* for a JSON column, not the nested object Strava sends. Passing the object through rejected the whole message with invalid_argument, so every activity carrying a photo silently dead-lettered while photo-less ones landed.

Confirmed in prod: activities_live held 0 of 4 rows with photos.primary populated against 133 in the legacy table, and the subscription logged 11 successes against 43 invalid_argument over two days. Activity 19587788065 showed it directly — Strava enriches asynchronously, so the first delivery (no photo yet) succeeded and the duplicate two minutes later (photo attached) showed it directly — Strava enriches asynchronously, so the first delivery (no photo yet) succeeded and the duplicate two minutes later (photo attached) failed six times and dead-lettered.

BigQuery parses the text back into a JSON object on arrival, so the stored shape is unchanged; only the wire form differs. The existing test asserted the object survived unchanged, which encoded the bug — it now asserts JSON text and round-trips it.