### PR TITLE
fix(cdc): relax nested REQUIRED columns so the topic schema is compatible

### DIFF
--- a/schemas/bigquery/activities_live.json
+++ b/schemas/bigquery/activities_live.json
@@ -1,0 +1,1144 @@
+{
+  "schema": [
+    {
+      "mode": "REQUIRED",
+      "name": "id",
+      "type": "INTEGER",
+      "description": "Strava activity ID (primary key)"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "external_id",
+      "type": "STRING",
+      "description": "External activity ID"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "upload_id",
+      "type": "INTEGER",
+      "description": "Strava upload ID"
+    },
+    {
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "id",
+          "type": "INTEGER",
+          "description": "Athlete ID"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "resource_state",
+          "type": "INTEGER",
+          "description": "Resource state"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "athlete",
+      "type": "RECORD",
+      "description": "Athlete information"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "name",
+      "type": "STRING",
+      "description": "Activity name/title"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "distance",
+      "type": "FLOAT",
+      "description": "Activity distance in meters"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "moving_time",
+      "type": "INTEGER",
+      "description": "Moving time in seconds"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "elapsed_time",
+      "type": "INTEGER",
+      "description": "Total elapsed time in seconds"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "total_elevation_gain",
+      "type": "FLOAT",
+      "description": "Total elevation gain in meters"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "elev_high",
+      "type": "FLOAT",
+      "description": "Highest elevation in meters"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "elev_low",
+      "type": "FLOAT",
+      "description": "Lowest elevation in meters"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "type",
+      "type": "STRING",
+      "description": "Type of activity (Ride, VirtualRide, etc.)"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "sport_type",
+      "type": "STRING",
+      "description": "Sport type classification"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "start_date",
+      "type": "TIMESTAMP",
+      "description": "Activity start time (UTC)"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "start_date_local",
+      "type": "TIMESTAMP",
+      "description": "Activity start time in local timezone"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "timezone",
+      "type": "STRING",
+      "description": "Timezone of the activity"
+    },
+    {
+      "mode": "REPEATED",
+      "name": "start_latlng",
+      "type": "FLOAT",
+      "description": "Starting latitude and longitude coordinates"
+    },
+    {
+      "mode": "REPEATED",
+      "name": "end_latlng",
+      "type": "FLOAT",
+      "description": "Ending latitude and longitude coordinates"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "achievement_count",
+      "type": "INTEGER",
+      "description": "Number of achievements earned"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "kudos_count",
+      "type": "INTEGER",
+      "description": "Number of kudos received"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "comment_count",
+      "type": "INTEGER",
+      "description": "Number of comments"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "athlete_count",
+      "type": "INTEGER",
+      "description": "Number of athletes"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "photo_count",
+      "type": "INTEGER",
+      "description": "Number of photos"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "total_photo_count",
+      "type": "INTEGER",
+      "description": "Total photo count"
+    },
+    {
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "id",
+          "type": "STRING",
+          "description": "Map ID"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "polyline",
+          "type": "STRING",
+          "description": "Encoded polyline (not available from list endpoint)"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "resource_state",
+          "type": "INTEGER",
+          "description": "Resource state"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "summary_polyline",
+          "type": "STRING",
+          "description": "Summary encoded polyline"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "map",
+      "type": "RECORD",
+      "description": "Map data with polylines (polyline field not available from list endpoint)"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "trainer",
+      "type": "BOOLEAN",
+      "description": "Whether activity was on a trainer"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "commute",
+      "type": "BOOLEAN",
+      "description": "Whether activity was a commute"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "manual",
+      "type": "BOOLEAN",
+      "description": "Whether activity was manually entered"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "private",
+      "type": "BOOLEAN",
+      "description": "Whether activity is private"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "flagged",
+      "type": "BOOLEAN",
+      "description": "Whether activity was flagged"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "workout_type",
+      "type": "STRING",
+      "description": "Type of workout"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "upload_id_str",
+      "type": "STRING",
+      "description": "Upload ID as string"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "average_speed",
+      "type": "FLOAT",
+      "description": "Average speed in m/s"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "max_speed",
+      "type": "FLOAT",
+      "description": "Maximum speed in m/s"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "has_kudoed",
+      "type": "BOOLEAN",
+      "description": "Whether user has kudoed this activity"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "hide_from_home",
+      "type": "BOOLEAN",
+      "description": "Whether to hide from home feed (not available from list endpoint)"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "gear_id",
+      "type": "STRING",
+      "description": "ID of gear used"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "kilojoules",
+      "type": "FLOAT",
+      "description": "Total energy output in kilojoules"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "average_watts",
+      "type": "FLOAT",
+      "description": "Average power output in watts"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "device_watts",
+      "type": "BOOLEAN",
+      "description": "Whether watts are from device"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "max_watts",
+      "type": "INTEGER",
+      "description": "Maximum power output in watts"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "weighted_average_watts",
+      "type": "INTEGER",
+      "description": "Weighted average power in watts"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "description",
+      "type": "STRING",
+      "description": "Activity description"
+    },
+    {
+      "fields": [
+        {
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "id",
+              "type": "STRING",
+              "description": "Photo ID"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "media_type",
+              "type": "INTEGER",
+              "description": "Media type"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "source",
+              "type": "INTEGER",
+              "description": "Photo source"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "unique_id",
+              "type": "STRING",
+              "description": "Unique photo ID"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "urls",
+              "type": "JSON",
+              "description": "Photo URLs as JSON"
+            }
+          ],
+          "mode": "NULLABLE",
+          "name": "primary",
+          "type": "RECORD",
+          "description": "Primary photo"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "count",
+          "type": "INTEGER",
+          "description": "Total photo count"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "photos",
+      "type": "RECORD",
+      "description": "Photo information (not available from list endpoint)"
+    },
+    {
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "id",
+          "type": "STRING",
+          "description": "Gear ID"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "primary",
+          "type": "BOOLEAN",
+          "description": "Whether this is primary gear"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "name",
+          "type": "STRING",
+          "description": "Gear name"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "resource_state",
+          "type": "INTEGER",
+          "description": "Resource state"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "distance",
+          "type": "FLOAT",
+          "description": "Total distance on gear"
+        }
+      ],
+      "mode": "NULLABLE",
+      "name": "gear",
+      "type": "RECORD",
+      "description": "Gear information"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "calories",
+      "type": "FLOAT",
+      "description": "Calories burned (may be null from list endpoint)"
+    },
+    {
+      "mode": "REPEATED",
+      "name": "segment_efforts",
+      "type": "RECORD",
+      "description": "Segment efforts data",
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "id",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "resource_state",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "name",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "activity",
+          "type": "RECORD",
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "id",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "resource_state",
+              "type": "INTEGER"
+            }
+          ]
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "athlete",
+          "type": "RECORD",
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "id",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "resource_state",
+              "type": "INTEGER"
+            }
+          ]
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "elapsed_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "moving_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "start_date",
+          "type": "TIMESTAMP"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "start_date_local",
+          "type": "TIMESTAMP"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "distance",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "start_index",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "end_index",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "average_cadence",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "device_watts",
+          "type": "BOOLEAN"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "average_watts",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "segment",
+          "type": "RECORD",
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "id",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "resource_state",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "name",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "activity_type",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "distance",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "average_grade",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "maximum_grade",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "elevation_high",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "elevation_low",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "REPEATED",
+              "name": "start_latlng",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "REPEATED",
+              "name": "end_latlng",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "climb_category",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "city",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "state",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "country",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "private",
+              "type": "BOOLEAN"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "hazardous",
+              "type": "BOOLEAN"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "starred",
+              "type": "BOOLEAN"
+            }
+          ]
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "kom_rank",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "pr_rank",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "hidden",
+          "type": "BOOLEAN"
+        }
+      ]
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "device_name",
+      "type": "STRING",
+      "description": "Device name"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "embed_token",
+      "type": "STRING",
+      "description": "Embed token (not available from list endpoint)"
+    },
+    {
+      "mode": "REPEATED",
+      "name": "splits_metric",
+      "type": "RECORD",
+      "description": "Metric splits data",
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "distance",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "elapsed_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "elevation_difference",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "moving_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "split",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "average_speed",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "pace_zone",
+          "type": "INTEGER"
+        }
+      ]
+    },
+    {
+      "mode": "REPEATED",
+      "name": "splits_standard",
+      "type": "RECORD",
+      "description": "Standard splits data",
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "distance",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "elapsed_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "elevation_difference",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "moving_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "split",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "average_speed",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "pace_zone",
+          "type": "INTEGER"
+        }
+      ]
+    },
+    {
+      "mode": "REPEATED",
+      "name": "laps",
+      "type": "RECORD",
+      "description": "Lap data",
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "id",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "resource_state",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "name",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "activity",
+          "type": "RECORD",
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "id",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "resource_state",
+              "type": "INTEGER"
+            }
+          ]
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "athlete",
+          "type": "RECORD",
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "id",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "resource_state",
+              "type": "INTEGER"
+            }
+          ]
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "elapsed_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "moving_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "start_date",
+          "type": "TIMESTAMP"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "start_date_local",
+          "type": "TIMESTAMP"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "distance",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "start_index",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "end_index",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "total_elevation_gain",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "average_speed",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "max_speed",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "average_cadence",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "device_watts",
+          "type": "BOOLEAN"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "average_watts",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "lap_index",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "split",
+          "type": "INTEGER"
+        }
+      ]
+    },
+    {
+      "mode": "REPEATED",
+      "name": "best_efforts",
+      "type": "RECORD",
+      "description": "Best efforts data",
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "id",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "resource_state",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "name",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "activity",
+          "type": "RECORD",
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "id",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "resource_state",
+              "type": "INTEGER"
+            }
+          ]
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "athlete",
+          "type": "RECORD",
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "id",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "resource_state",
+              "type": "INTEGER"
+            }
+          ]
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "elapsed_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "moving_time",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "start_date",
+          "type": "TIMESTAMP"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "start_date_local",
+          "type": "TIMESTAMP"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "distance",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "start_index",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "end_index",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "average_cadence",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "device_watts",
+          "type": "BOOLEAN"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "average_watts",
+          "type": "FLOAT"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "segment",
+          "type": "RECORD",
+          "fields": [
+            {
+              "mode": "NULLABLE",
+              "name": "id",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "resource_state",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "name",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "activity_type",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "distance",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "average_grade",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "maximum_grade",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "elevation_high",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "elevation_low",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "REPEATED",
+              "name": "start_latlng",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "REPEATED",
+              "name": "end_latlng",
+              "type": "FLOAT"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "climb_category",
+              "type": "INTEGER"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "city",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "state",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "country",
+              "type": "STRING"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "private",
+              "type": "BOOLEAN"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "hazardous",
+              "type": "BOOLEAN"
+            },
+            {
+              "mode": "NULLABLE",
+              "name": "starred",
+              "type": "BOOLEAN"
+            }
+          ]
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "kom_rank",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "pr_rank",
+          "type": "INTEGER"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "hidden",
+          "type": "BOOLEAN"
+        }
+      ]
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "average_cadence",
+      "type": "FLOAT",
+      "description": "Average cadence"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "has_heartrate",
+      "type": "BOOLEAN",
+      "description": "Whether activity has heartrate data"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "pr_count",
+      "type": "INTEGER",
+      "description": "Number of personal records"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "suffer_score",
+      "type": "FLOAT",
+      "description": "Strava suffer score"
+    },
+    {
+      "mode": "REPEATED",
+      "name": "stats_visibility",
+      "type": "RECORD",
+      "description": "Stats visibility settings",
+      "fields": [
+        {
+          "mode": "NULLABLE",
+          "name": "type",
+          "type": "STRING"
+        },
+        {
+          "mode": "NULLABLE",
+          "name": "visibility",
+          "type": "STRING"
+        }
+      ]
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "display_hide_heartrate_option",
+      "type": "BOOLEAN",
+      "description": "Whether to display hide heartrate option"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "heartrate_opt_out",
+      "type": "BOOLEAN",
+      "description": "Whether user opted out of heartrate"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "average_heartrate",
+      "type": "FLOAT",
+      "description": "Average heart rate in beats per minute"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "max_heartrate",
+      "type": "FLOAT",
+      "description": "Maximum heart rate in beats per minute"
+    },
+    {
+      "mode": "REPEATED",
+      "name": "available_zones",
+      "type": "STRING",
+      "description": "Available zones"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "visibility",
+      "type": "STRING",
+      "description": "Activity visibility setting"
+    }
+  ]
+}

--- a/schemas/bigquery/generate_proto.py
+++ b/schemas/bigquery/generate_proto.py
@@ -181,6 +181,27 @@ PROFILES: tuple[_Profile, ...] = (STORAGE_WRITE, PUBSUB_CDC)
 # the next free one in their message. Numbers are never reused.
 FIELD_NUMBERS_PATH = REPO_ROOT / "schemas/bigquery/cdc_field_numbers.json"
 
+# The destination table schema for the CDC path, derived from
+# activities_full.json with every mode except the primary key relaxed.
+#
+# Two independent reasons, both discovered the hard way:
+#
+#   1. A CDC delete is addressed by primary key alone. Under use_table_schema
+#      the subscription validates each message against the table, so any
+#      REQUIRED column a delete cannot supply rejects the delete outright.
+#   2. Under use_topic_schema Pub/Sub compares the two *schemas* statically,
+#      before any message exists. Every field is `optional` in proto2, so a
+#      REQUIRED column at any depth fails with INCOMPATIBLE_MODE — including
+#      nested ones, which reason (1) alone would have left alone.
+#
+# Generated rather than transformed in HCL: the nesting is three deep, HCL
+# cannot recurse, and merge() would inject a null `fields` key onto scalars.
+LIVE_SCHEMA_PATH = REPO_ROOT / "schemas/bigquery/activities_live.json"
+
+# The one column that must stay REQUIRED: BigQuery requires a primary-key
+# column to be non-nullable, and every message supplies it.
+_PRIMARY_KEY = "id"
+
 # Guard for the positional numbering in _emit_message: growing the table past
 # these would silently collide with the pins.
 _PINNED_FIELD_NUMBERS: frozenset[int] = frozenset(
@@ -331,6 +352,24 @@ def _emit_field(col: dict[str, Any], field_number: int, out: _Emit) -> None:
     out.write(f"{prefix}{type_name} {name} = {field_number};{suffix}")
 
 
+def relax_schema(fields: list[dict[str, Any]], depth: int = 0) -> list[dict[str, Any]]:
+    """Return the schema with every REQUIRED mode relaxed to NULLABLE.
+
+    The top-level primary key is the sole exception. REPEATED is left alone —
+    it is a cardinality, not a nullability, and proto `repeated` matches it.
+    """
+    relaxed: list[dict[str, Any]] = []
+    for field in fields:
+        copy = dict(field)
+        keep_required = depth == 0 and copy["name"] == _PRIMARY_KEY
+        if copy.get("mode") == "REQUIRED" and not keep_required:
+            copy["mode"] = "NULLABLE"
+        if copy.get("fields"):
+            copy["fields"] = relax_schema(copy["fields"], depth + 1)
+        relaxed.append(copy)
+    return relaxed
+
+
 def load_field_numbers() -> dict[str, int]:
     """Read the committed field-number lock, or start empty on first run.
 
@@ -478,6 +517,29 @@ def main(argv: list[str] | None = None) -> int:
         profile.output_path.parent.mkdir(parents=True, exist_ok=True)
         profile.output_path.write_text(content)
         print(f"OK: generated {rel_output} ({len(content)} bytes)")
+
+    live_schema = (
+        json.dumps(
+            {"schema": relax_schema(json.loads(BQ_SCHEMA_PATH.read_text())["schema"])},
+            indent=2,
+        )
+        + "\n"
+    )
+    rel_live = LIVE_SCHEMA_PATH.relative_to(REPO_ROOT).as_posix()
+    if check_only:
+        existing = LIVE_SCHEMA_PATH.read_text() if LIVE_SCHEMA_PATH.exists() else ""
+        if existing != live_schema:
+            print(
+                f"FAIL: {rel_live} is out of sync with activities_full.json.\n"
+                "   Run: just generate-bq-proto",
+                file=sys.stderr,
+            )
+            failed = True
+        else:
+            print(f"OK: {rel_live} is in sync")
+    else:
+        LIVE_SCHEMA_PATH.write_text(live_schema)
+        print(f"OK: generated {rel_live} ({len(live_schema)} bytes)")
 
     if not check_only:
         FIELD_NUMBERS_PATH.write_text(

--- a/schemas/bigquery/test_generate_proto.py
+++ b/schemas/bigquery/test_generate_proto.py
@@ -407,3 +407,55 @@ class TestFieldNumberLock:
         for key, value in lock.items():
             if key in numbers:
                 assert numbers[key] == value, f"{key} drifted from the lock"
+
+
+class TestLiveTableSchema:
+    """The CDC table cannot declare REQUIRED columns beyond its primary key.
+
+    Two independent reasons, both found in prod: a CDC delete carries only the
+    key, so under use_table_schema any REQUIRED column rejects it; and under
+    use_topic_schema Pub/Sub compares the schemas statically, where every
+    proto2 field is `optional`, so a REQUIRED column at any depth fails the
+    subscription update with INCOMPATIBLE_MODE.
+    """
+
+    def _required_paths(self, fields: list[dict], prefix: str = "") -> list[str]:
+        found = []
+        for field in fields:
+            path = f"{prefix}{field['name']}"
+            if field.get("mode") == "REQUIRED":
+                found.append(path)
+            if field.get("fields"):
+                found += self._required_paths(field["fields"], path + ".")
+        return found
+
+    def test_only_the_primary_key_stays_required(self):
+        schema = json.loads(BQ_SCHEMA_PATH.read_text())["schema"]
+        assert self._required_paths(generate_proto.relax_schema(schema)) == ["id"]
+
+    def test_nested_required_fields_are_relaxed(self):
+        """The case that broke the dev apply: `laps.start_date`."""
+        schema = json.loads(BQ_SCHEMA_PATH.read_text())["schema"]
+        source_nested = [p for p in self._required_paths(schema) if "." in p]
+        assert source_nested, "fixture no longer exercises nested REQUIRED fields"
+        assert "laps.start_date" in source_nested
+
+        relaxed = generate_proto.relax_schema(schema)
+        assert not [p for p in self._required_paths(relaxed) if "." in p]
+
+    def test_repeated_is_left_alone(self):
+        """REPEATED is cardinality, not nullability; proto `repeated` matches it."""
+        schema = json.loads(BQ_SCHEMA_PATH.read_text())["schema"]
+        before = {f["name"] for f in schema if f.get("mode") == "REPEATED"}
+        after = {
+            f["name"]
+            for f in generate_proto.relax_schema(schema)
+            if f.get("mode") == "REPEATED"
+        }
+        assert before, "fixture no longer exercises REPEATED fields"
+        assert before == after
+
+    def test_the_committed_live_schema_matches(self):
+        schema = json.loads(BQ_SCHEMA_PATH.read_text())["schema"]
+        committed = json.loads(generate_proto.LIVE_SCHEMA_PATH.read_text())["schema"]
+        assert committed == generate_proto.relax_schema(schema)

--- a/terraform/modules/desirelines/bigquery_subscription.tf
+++ b/terraform/modules/desirelines/bigquery_subscription.tf
@@ -126,22 +126,21 @@ resource "google_pubsub_subscription" "activity_rows_dlq_monitoring" {
 # and the delete dead-letters instead of removing the row. So a CDC table whose
 # producer issues deletes cannot declare REQUIRED columns beyond its key.
 #
-# `id` stays REQUIRED — BigQuery requires a primary-key column to be
-# non-nullable, and every message supplies it. Nested REQUIRED fields are left
-# alone: their parent records are nullable, so a delete simply omits the parent
-# and never has to satisfy them. Upserts are unaffected — they still carry the
-# full row.
-locals {
-  activities_full_schema = jsondecode(file("${path.module}/../../../schemas/bigquery/activities_full.json")).schema
-
-  activities_live_schema = [
-    for field in local.activities_full_schema :
-    field.name == "id" ? field : merge(field, {
-      mode = field.mode == "REQUIRED" ? "NULLABLE" : field.mode
-    })
-  ]
-}
-
+# Under use_topic_schema there is a second, stricter reason. Pub/Sub compares
+# the topic schema against the table schema statically, before any message
+# exists, and proto2 labels every field `optional`. A REQUIRED column at ANY
+# depth then fails the subscription update outright:
+#
+#   "Incompatible schema: field laps.start_date is required in table, but
+#    nullable in topic"
+#
+# So nested REQUIRED fields cannot survive either — 106 of them. `id` is the
+# sole exception, since BigQuery requires a primary-key column to be
+# non-nullable and every message supplies it.
+#
+# The relaxed schema is generated rather than transformed here: the nesting is
+# three deep, HCL cannot recurse, and merge() would attach a null `fields` key
+# to every scalar. See schemas/bigquery/generate_proto.py.
 resource "google_bigquery_table" "activities_live" {
   dataset_id          = google_bigquery_dataset.activities_dataset.dataset_id
   table_id            = "activities_live"
@@ -151,7 +150,7 @@ resource "google_bigquery_table" "activities_live" {
 
   labels = local.common_labels
 
-  schema = jsonencode(local.activities_live_schema)
+  schema = jsonencode(jsondecode(file("${path.module}/../../../schemas/bigquery/activities_live.json")).schema)
 
   # CDC upserts/deletes key on this primary key (non-enforced in BigQuery).
   table_constraints {


### PR DESCRIPTION
Flipping dev to protobuf failed the subscription update:

  Incompatible schema: field laps.start_date is required in table, but
  nullable in topic

Under use_table_schema Pub/Sub validates each message against the table, so relaxing the top-level columns was enough — that is what made CDC deletes work, since a delete carries only the primary key. Under use_topic_schema it compares the two schemas statically, before any message exists, and proto2 labels every field `optional`. A REQUIRED column at any depth is then incompatible, nested ones included. There are 106 of them, three levels deep.

The relaxed schema moves out of HCL and into the generator, emitted as schemas/bigquery/activities_live.json. HCL cannot recurse, and merge() would attach a null `fields` key to every scalar, so the previous one-level comprehension could not have been extended to cover this. Generating it also puts it under verify-schemas, so it cannot drift from activities_full.json.

Only modes change: the structure is identical to the source schema and `id` stays REQUIRED, which BigQuery demands of a primary-key column. REPEATED is untouched — it is cardinality, not nullability, and proto `repeated` matches it.