### PR TITLE
fix(deletion): purge activities_live on deauth, and stop archiving deleted data

### DIFF
--- a/packages/stravapipe/src/stravapipe/application/bq_inserter/delete_service.py
+++ b/packages/stravapipe/src/stravapipe/application/bq_inserter/delete_service.py
@@ -1,4 +1,15 @@
-"""Service for archiving deleted activities to BigQuery"""
+"""Remove a deleted activity from the legacy BigQuery activities table.
+
+This previously copied the activity into a `deleted_activities` table before
+deleting it, described as an audit trail. It was not one — the copy carried the
+whole activity payload, so a deletion moved the data rather than removing it.
+The record of a deletion is now the log line below.
+
+Legacy path. The CDC subscription already deletes natively: the dispatcher
+publishes `_CHANGE_TYPE=DELETE` and BigQuery removes the row from
+`activities_live` with no DML and no service. This exists only for the
+`activities` table and retires with it.
+"""
 
 from dataclasses import dataclass
 import logging
@@ -14,15 +25,14 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class BQActivityDeletionResult:
-    """Result of archiving a single deleted activity to BigQuery."""
+    """Result of deleting a single activity from BigQuery."""
 
     activity_id: int
-    rows_archived: int
     rows_deleted: int
 
 
 class DeleteActivityService:
-    """Archive deleted activity from activities to deleted_activities table"""
+    """Delete a single activity from the legacy `activities` table."""
 
     def __init__(
         self,
@@ -67,9 +77,9 @@ class DeleteActivityService:
             event_time: Strava webhook event_time.
 
         Returns:
-            BQActivityDeletionResult with row counts. ``rows_archived == 0``
-            indicates the activity was not found (and ``rows_deleted`` will
-            also be 0 because the DELETE step is skipped).
+            BQActivityDeletionResult. ``rows_deleted == 0`` indicates the
+            activity was not in the table — already deleted, or never
+            inserted.
 
         Raises:
             BigQueryError: If archiving fails (will trigger retry via DLQ).
@@ -79,49 +89,6 @@ class DeleteActivityService:
             activity_id,
             extra={"correlation_id": correlation_id, "activity_id": activity_id},
         )
-
-        # Archive activity into deleted_activities
-        insert_query = f"""
-        INSERT INTO {self._table("deleted_activities")}
-        SELECT
-            *,
-            CURRENT_TIMESTAMP() AS deleted_at,
-            @event_time AS deletion_event_time,
-            @correlation_id AS deletion_correlation_id
-        FROM {self._table("activities")}
-        WHERE id = @activity_id
-        """
-
-        with record_span(
-            self._tracer,
-            "bigquery.archive_insert",
-            db_attributes(
-                "bigquery",
-                self._dataset_id,
-                "INSERT",
-                {"desirelines.activity_id": activity_id},
-            ),
-        ):
-            rows_archived = self._client.execute_dml_query(
-                insert_query,
-                [
-                    ScalarQueryParameter("activity_id", "INT64", activity_id),
-                    ScalarQueryParameter("event_time", "INT64", event_time),
-                    ScalarQueryParameter("correlation_id", "STRING", correlation_id),
-                ],
-            )
-
-        if rows_archived == 0:
-            logger.warning(
-                "Activity %s not found for deletion (may have been deleted already)",
-                activity_id,
-                extra={"correlation_id": correlation_id},
-            )
-            return BQActivityDeletionResult(
-                activity_id=activity_id,
-                rows_archived=0,
-                rows_deleted=0,
-            )
 
         # Delete from activities table
         delete_query = f"""
@@ -145,7 +112,7 @@ class DeleteActivityService:
             )
 
         logger.info(
-            "Successfully archived deleted activity %s",
+            "Deleted activity %s from BigQuery",
             activity_id,
             extra={
                 "correlation_id": correlation_id,
@@ -156,6 +123,5 @@ class DeleteActivityService:
 
         return BQActivityDeletionResult(
             activity_id=activity_id,
-            rows_archived=rows_archived,
             rows_deleted=rows_deleted,
         )

--- a/packages/stravapipe/src/stravapipe/application/bq_inserter/delete_service.py
+++ b/packages/stravapipe/src/stravapipe/application/bq_inserter/delete_service.py
@@ -1,14 +1,7 @@
-"""Remove a deleted activity from the legacy BigQuery activities table.
+"""Remove a deleted activity from the legacy BigQuery `activities` table.
 
-This previously copied the activity into a `deleted_activities` table before
-deleting it, described as an audit trail. It was not one — the copy carried the
-whole activity payload, so a deletion moved the data rather than removing it.
-The record of a deletion is now the log line below.
-
-Legacy path. The CDC subscription already deletes natively: the dispatcher
-publishes `_CHANGE_TYPE=DELETE` and BigQuery removes the row from
-`activities_live` with no DML and no service. This exists only for the
-`activities` table and retires with it.
+Legacy path — `activities_live` needs no equivalent, since the CDC subscription
+applies the dispatcher's `_CHANGE_TYPE=DELETE` natively. Retires with the table.
 """
 
 from dataclasses import dataclass

--- a/packages/stravapipe/src/stravapipe/application/deletion/bq_user_deletion_service.py
+++ b/packages/stravapipe/src/stravapipe/application/deletion/bq_user_deletion_service.py
@@ -1,31 +1,16 @@
-"""BigQuery user deletion service for Strava deauthorization.
+"""Delete an athlete's BigQuery data on Strava deauthorization.
 
-When a user disconnects the app from Strava, the Strava API Agreement
-(Section 5.4, https://www.strava.com/legal/api) requires that all user
-data is deleted within 48 hours.
+Required within 48 hours by the Strava API Agreement §5.4
+(https://www.strava.com/legal/api). Covers every table holding activity rows:
+`activities`, `activities_staging`, and `activities_live`.
 
-This service handles the BigQuery portion of that deletion, removing the
-athlete's rows from every table that holds them:
+Nothing is archived. The deletion record is the log line below — athlete id,
+row counts, correlation id — which is what evidences a deletion without
+retaining what was deleted.
 
-1. activities        — the legacy table written by bq-inserter
-2. activities_staging — its landing zone
-3. activities_live   — the CDC table written by the Pub/Sub subscription
-
-**The record of a deletion is the log line, not a table.** An earlier version
-copied every row into a `deleted_activities` table first, described as an audit
-trail. It was not one: 64 of its 67 columns were the activity payload —
-athlete, route polylines, start/end coordinates, photos, description — so a
-deauthorization moved the data rather than deleting it, under a name that read
-as handled. Proving a deletion happened needs the athlete id, a timestamp, a
-row count and a correlation id; it does not need the data that was deleted.
-Those four are logged below and retained in Cloud Logging.
-
-DML rather than CDC deletes for `activities_live`, deliberately. A per-activity
-delete already flows through CDC — the dispatcher publishes `_CHANGE_TYPE=DELETE`
-and the subscription applies it — but a deauthorization removes every activity an
-athlete has, which as CDC messages would be one publish per activity (thousands
-for an established account) and eventually consistent, against a single DML
-statement that returns the row count it deleted.
+DML rather than CDC deletes for `activities_live`: a deauthorization removes
+every activity an athlete has, which as CDC messages would be one publish each
+and eventually consistent, against one statement that returns its row count.
 
 All operations are idempotent — safe to retry on partial failure via
 Pub/Sub dead-letter redelivery.
@@ -100,9 +85,8 @@ class BQUserDeletionService:
         staging_deleted = purge("activities_staging")
         live_deleted = purge("activities_live")
 
-        # This is the deletion record. It carries what proving a deletion
-        # requires — who, when, how much, and the correlation id to tie it to
-        # the deauthorization event — and none of what was deleted.
+        # The deletion record: who, when, how much — and none of what was
+        # deleted. Retained in Cloud Logging.
         logger.info(
             "Deleted BigQuery data for user %s: activities=%d staging=%d live=%d",
             user_id,

--- a/packages/stravapipe/src/stravapipe/application/deletion/bq_user_deletion_service.py
+++ b/packages/stravapipe/src/stravapipe/application/deletion/bq_user_deletion_service.py
@@ -4,16 +4,28 @@ When a user disconnects the app from Strava, the Strava API Agreement
 (Section 5.4, https://www.strava.com/legal/api) requires that all user
 data is deleted within 48 hours.
 
-This service handles the BigQuery portion of that deletion:
-1. Archive activities → deleted_activities (audit trail with deletion metadata)
-2. Delete from activities (primary table)
-3. Delete from activities_staging (landing zone for new data)
+This service handles the BigQuery portion of that deletion, removing the
+athlete's rows from every table that holds them:
 
-The deleted_activities archive is intentionally retained. It serves as an
-audit trail proving deletion occurred, containing only the activity data
-that was present at deletion time plus deletion metadata (deleted_at,
-correlation_id). This mirrors the per-activity DeleteActivityService
-pattern used when individual activities are deleted via webhook.
+1. activities        — the legacy table written by bq-inserter
+2. activities_staging — its landing zone
+3. activities_live   — the CDC table written by the Pub/Sub subscription
+
+**The record of a deletion is the log line, not a table.** An earlier version
+copied every row into a `deleted_activities` table first, described as an audit
+trail. It was not one: 64 of its 67 columns were the activity payload —
+athlete, route polylines, start/end coordinates, photos, description — so a
+deauthorization moved the data rather than deleting it, under a name that read
+as handled. Proving a deletion happened needs the athlete id, a timestamp, a
+row count and a correlation id; it does not need the data that was deleted.
+Those four are logged below and retained in Cloud Logging.
+
+DML rather than CDC deletes for `activities_live`, deliberately. A per-activity
+delete already flows through CDC — the dispatcher publishes `_CHANGE_TYPE=DELETE`
+and the subscription applies it — but a deauthorization removes every activity an
+athlete has, which as CDC messages would be one publish per activity (thousands
+for an established account) and eventually consistent, against a single DML
+statement that returns the row count it deleted.
 
 All operations are idempotent — safe to retry on partial failure via
 Pub/Sub dead-letter redelivery.
@@ -33,18 +45,18 @@ logger = logging.getLogger(__name__)
 class BQDeletionResult:
     """Result of BigQuery user data deletion."""
 
-    activities_archived: int
     activities_deleted: int
     staging_deleted: int
+    live_deleted: int
 
 
 class BQUserDeletionService:
     """Delete all BigQuery data for a user on deauthorization.
 
     Process:
-    1. Archive activities to deleted_activities table (audit trail)
-    2. Delete from activities table
-    3. Delete from activities_staging table
+    1. Delete from activities
+    2. Delete from activities_staging
+    3. Delete from activities_live
     """
 
     def __init__(self, client: BigQueryClientWrapper, *, dataset_id: str):
@@ -74,62 +86,34 @@ class BQUserDeletionService:
         """
         user_id_param = ScalarQueryParameter("user_id", "STRING", user_id)
 
-        # 1. Archive activities to deleted_activities
-        archive_query = f"""
-        INSERT INTO {self._table("deleted_activities")}
-        SELECT
-            *,
-            CURRENT_TIMESTAMP() AS deleted_at,
-            @event_time AS deletion_event_time,
-            @correlation_id AS deletion_correlation_id
-        FROM {self._table("activities")}
-        WHERE CAST(athlete.id AS STRING) = @user_id
-        """
-        activities_archived = self._client.execute_dml_query(
-            archive_query,
-            [
-                user_id_param,
-                ScalarQueryParameter("event_time", "INT64", event_time),
-                ScalarQueryParameter("correlation_id", "STRING", correlation_id),
-            ],
-        )
+        def purge(table: str) -> int:
+            """Delete the athlete's rows from one table."""
+            return self._client.execute_dml_query(
+                f"""
+                DELETE FROM {self._table(table)}
+                WHERE CAST(athlete.id AS STRING) = @user_id
+                """,
+                [user_id_param],
+            )
 
+        activities_deleted = purge("activities")
+        staging_deleted = purge("activities_staging")
+        live_deleted = purge("activities_live")
+
+        # This is the deletion record. It carries what proving a deletion
+        # requires — who, when, how much, and the correlation id to tie it to
+        # the deauthorization event — and none of what was deleted.
         logger.info(
-            "Archived %d activities for user %s",
-            activities_archived,
+            "Deleted BigQuery data for user %s: activities=%d staging=%d live=%d",
             user_id,
-            extra={"correlation_id": correlation_id},
+            activities_deleted,
+            staging_deleted,
+            live_deleted,
+            extra={"correlation_id": correlation_id, "event_time": event_time},
         )
 
-        # 2. Delete from activities
-        delete_activities = f"""
-        DELETE FROM {self._table("activities")}
-        WHERE CAST(athlete.id AS STRING) = @user_id
-        """
-        activities_deleted = self._client.execute_dml_query(
-            delete_activities, [user_id_param]
-        )
-
-        # 3. Delete from staging
-        delete_staging = f"""
-        DELETE FROM {self._table("activities_staging")}
-        WHERE CAST(athlete.id AS STRING) = @user_id
-        """
-        staging_deleted = self._client.execute_dml_query(
-            delete_staging, [user_id_param]
-        )
-
-        result = BQDeletionResult(
-            activities_archived=activities_archived,
+        return BQDeletionResult(
             activities_deleted=activities_deleted,
             staging_deleted=staging_deleted,
+            live_deleted=live_deleted,
         )
-
-        logger.info(
-            "BQ deletion complete for user %s: %s",
-            user_id,
-            result,
-            extra={"correlation_id": correlation_id},
-        )
-
-        return result

--- a/packages/stravapipe/src/stravapipe/cloudrun/bq_inserter_app.py
+++ b/packages/stravapipe/src/stravapipe/cloudrun/bq_inserter_app.py
@@ -259,7 +259,7 @@ async def _handle_delete(
             event_time=event.event_time,
         )
 
-    if result.rows_archived == 0:
+    if result.rows_deleted == 0:
         return WebhookResponse(
             status=ResponseStatus.SKIPPED,
             reason=SkipReason.ACTIVITY_NOT_FOUND,

--- a/packages/stravapipe/src/stravapipe/cloudrun/deletion_service_app.py
+++ b/packages/stravapipe/src/stravapipe/cloudrun/deletion_service_app.py
@@ -9,8 +9,8 @@ disconnects the app from Strava, this service deletes their data from all
 stores:
 
 - PostgreSQL: activities + routes (CASCADE)
-- BigQuery: archive to deleted_activities (audit trail), then delete from
-  activities and activities_staging
+- BigQuery: delete from activities, activities_staging and activities_live.
+  The deletion record is the log line, not a retained copy of the data.
 - Firestore: OAuth tokens, user profile, config, allowlist entry
 
 All deletions are idempotent. On partial failure, returns 500 to trigger
@@ -72,6 +72,7 @@ class DeletionResult:
     pg_deleted: int = 0
     bq_activities_deleted: int = 0
     bq_staging_deleted: int = 0
+    bq_live_deleted: int = 0
     firestore_tokens_deleted: bool = False
     firestore_user_docs_deleted: int = 0
     errors: list[str] = field(default_factory=list)
@@ -157,6 +158,7 @@ def _delete_all_stores(
         bq_result = deps.bq_service.run(user_id, correlation_id, event_time)
         result.bq_activities_deleted = bq_result.activities_deleted
         result.bq_staging_deleted = bq_result.staging_deleted
+        result.bq_live_deleted = bq_result.live_deleted
 
     def _do_firestore_tokens() -> None:
         deps.token_store.delete_tokens(user_id)
@@ -406,6 +408,7 @@ async def handle_deauth_event(request: Request) -> UserDeletionResponse:
                     "pg_deleted": result.pg_deleted,
                     "bq_activities_deleted": result.bq_activities_deleted,
                     "bq_staging_deleted": result.bq_staging_deleted,
+                    "bq_live_deleted": result.bq_live_deleted,
                     "firestore_docs_deleted": result.firestore_user_docs_deleted,
                 },
             )
@@ -417,6 +420,7 @@ async def handle_deauth_event(request: Request) -> UserDeletionResponse:
                 pg_deleted=result.pg_deleted,
                 bq_activities_deleted=result.bq_activities_deleted,
                 bq_staging_deleted=result.bq_staging_deleted,
+                bq_live_deleted=result.bq_live_deleted,
             )
 
     except HTTPException:

--- a/packages/stravapipe/src/stravapipe/shared/responses.py
+++ b/packages/stravapipe/src/stravapipe/shared/responses.py
@@ -46,3 +46,4 @@ class UserDeletionResponse(BaseModel):
     pg_deleted: int
     bq_activities_deleted: int
     bq_staging_deleted: int
+    bq_live_deleted: int

--- a/packages/stravapipe/tests/unit/application/bq_inserter/services/test_delete_service.py
+++ b/packages/stravapipe/tests/unit/application/bq_inserter/services/test_delete_service.py
@@ -15,11 +15,10 @@ def _make_service(client=None):
 
 
 def test_delete_activity_success():
-    """Test successful activity deletion"""
+    """A single DELETE removes the activity."""
     service, client = _make_service()
 
-    # First DML call (archive) returns 1 row, second (delete) returns 1 row
-    client.execute_dml_query.side_effect = [1, 1]
+    client.execute_dml_query.return_value = 1
 
     result = service.run(
         activity_id=123456,
@@ -28,16 +27,18 @@ def test_delete_activity_success():
     )
 
     assert result.activity_id == 123456
-    assert result.rows_archived == 1
     assert result.rows_deleted == 1
-    assert client.execute_dml_query.call_count == 2
+    assert client.execute_dml_query.call_count == 1
 
 
 def test_delete_activity_not_found():
-    """Test deletion when activity doesn't exist"""
+    """A missing activity deletes nothing and is not an error.
+
+    Already deleted, or never inserted — either way the desired end state
+    holds, so the caller treats it as a skip rather than a failure.
+    """
     service, client = _make_service()
 
-    # Archive returns 0 rows — activity not found
     client.execute_dml_query.return_value = 0
 
     result = service.run(
@@ -47,35 +48,30 @@ def test_delete_activity_not_found():
     )
 
     assert result.activity_id == 999999
-    assert result.rows_archived == 0
     assert result.rows_deleted == 0
-    # Should only run archive query, not delete
-    assert client.execute_dml_query.call_count == 1
 
 
-def test_delete_activity_insert_error():
-    """Test deletion when archive insert fails"""
+def test_delete_activity_retains_no_copy():
+    """Deletion must not archive the row into another table.
+
+    This service used to INSERT the activity into `deleted_activities` first,
+    which retained the very data the deletion existed to remove.
+    """
     service, client = _make_service()
+    client.execute_dml_query.return_value = 1
 
-    client.execute_dml_query.side_effect = BigQueryError("BigQuery insert failed")
+    service.run(activity_id=123456, correlation_id="c", event_time=1696176000)
 
-    with pytest.raises(BigQueryError, match="BigQuery insert failed"):
-        service.run(
-            activity_id=123456,
-            correlation_id="test-789",
-            event_time=1696176000,
-        )
+    query = client.execute_dml_query.call_args.args[0]
+    assert "INSERT" not in query.upper()
+    assert "deleted_activities" not in query
 
 
 def test_delete_activity_delete_error():
-    """Test deletion when delete query fails after successful archive"""
+    """A failed delete propagates, so Pub/Sub redelivers."""
     service, client = _make_service()
 
-    # Archive succeeds (1 row), delete fails
-    client.execute_dml_query.side_effect = [
-        1,
-        BigQueryError("BigQuery delete failed"),
-    ]
+    client.execute_dml_query.side_effect = BigQueryError("BigQuery delete failed")
 
     with pytest.raises(BigQueryError, match="BigQuery delete failed"):
         service.run(

--- a/packages/stravapipe/tests/unit/application/bq_inserter/services/test_delete_service.py
+++ b/packages/stravapipe/tests/unit/application/bq_inserter/services/test_delete_service.py
@@ -52,11 +52,7 @@ def test_delete_activity_not_found():
 
 
 def test_delete_activity_retains_no_copy():
-    """Deletion must not archive the row into another table.
-
-    This service used to INSERT the activity into `deleted_activities` first,
-    which retained the very data the deletion existed to remove.
-    """
+    """No archive table: a copy of the row would defeat the deletion."""
     service, client = _make_service()
     client.execute_dml_query.return_value = 1
 

--- a/packages/stravapipe/tests/unit/application/deletion/test_bq_user_deletion_service.py
+++ b/packages/stravapipe/tests/unit/application/deletion/test_bq_user_deletion_service.py
@@ -24,50 +24,63 @@ def service(mock_client):
 
 
 class TestBQUserDeletionService:
-    def test_archives_then_deletes_from_all_tables(self, service, mock_client):
-        """Archives activities for audit trail, then deletes from active tables."""
-        mock_client.execute_dml_query.side_effect = [5, 5, 2]
+    def test_deletes_from_every_table_holding_the_user(self, service, mock_client):
+        """activities, its staging table, and the CDC table."""
+        mock_client.execute_dml_query.side_effect = [5, 2, 5]
 
         result = service.run("12345", "corr-123", 1704067200)
 
-        # 3 DML calls: archive, delete activities, delete staging
         assert mock_client.execute_dml_query.call_count == 3
-        assert result.activities_archived == 5
         assert result.activities_deleted == 5
         assert result.staging_deleted == 2
+        assert result.live_deleted == 5
+
+    def test_purges_activities_live(self, service, mock_client):
+        """The CDC table is covered — it was the gap this closes.
+
+        activities_live is written by the Pub/Sub subscription and is the only
+        BigQuery activity table left after the cutover, so a deauthorization
+        that skipped it would leave the athlete's data behind.
+        """
+        mock_client.execute_dml_query.side_effect = [0, 0, 0]
+        service.run("12345", "corr-123", 1704067200)
+
+        queries = [c.args[0] for c in mock_client.execute_dml_query.call_args_list]
+        assert any("activities_live" in q for q in queries)
+
+    def test_retains_no_copy_of_the_deleted_data(self, service, mock_client):
+        """Deletion must not archive the rows into another table.
+
+        An earlier version copied every row into `deleted_activities` as an
+        "audit trail", which retained exactly the data the deletion was required
+        to remove. The record is the log line instead.
+        """
+        mock_client.execute_dml_query.side_effect = [1, 1, 1]
+        service.run("12345", "corr-123", 1704067200)
+
+        queries = [c.args[0] for c in mock_client.execute_dml_query.call_args_list]
+        assert not any("INSERT" in q.upper() for q in queries)
+        assert not any("deleted_activities" in q for q in queries)
 
     def test_handles_no_data_to_delete(self, service, mock_client):
         mock_client.execute_dml_query.side_effect = [0, 0, 0]
 
         result = service.run("99999", "corr-456", 1704067200)
 
-        assert result.activities_archived == 0
         assert result.activities_deleted == 0
         assert result.staging_deleted == 0
+        assert result.live_deleted == 0
 
     def test_uses_parameterized_queries(self, service, mock_client):
+        """The athlete id reaches BigQuery as a bound parameter, never inlined."""
         mock_client.execute_dml_query.side_effect = [0, 0, 0]
 
         service.run("12345", "corr-123", 1704067200)
 
-        # Each call gets a query and parameters
         for call in mock_client.execute_dml_query.call_args_list:
-            _query, params = call.args
-            assert params is not None
-            assert len(params) > 0
-
-        # Archive query (first call) includes event_time and correlation_id params
-        _, archive_params = mock_client.execute_dml_query.call_args_list[0].args
-        param_names = [p.name for p in archive_params]
-        assert "user_id" in param_names
-        assert "event_time" in param_names
-        assert "correlation_id" in param_names
-
-        # Delete queries (calls 2-3) only have user_id param
-        for call in mock_client.execute_dml_query.call_args_list[1:]:
-            _, params = call.args
-            param_names = [p.name for p in params]
-            assert param_names == ["user_id"]
+            query, params = call.args
+            assert [p.name for p in params] == ["user_id"]
+            assert "12345" not in query
 
     def test_raises_on_bq_failure(self, service, mock_client):
         mock_client.execute_dml_query.side_effect = BigQueryError("BQ error")

--- a/packages/stravapipe/tests/unit/application/deletion/test_bq_user_deletion_service.py
+++ b/packages/stravapipe/tests/unit/application/deletion/test_bq_user_deletion_service.py
@@ -36,12 +36,7 @@ class TestBQUserDeletionService:
         assert result.live_deleted == 5
 
     def test_purges_activities_live(self, service, mock_client):
-        """The CDC table is covered — it was the gap this closes.
-
-        activities_live is written by the Pub/Sub subscription and is the only
-        BigQuery activity table left after the cutover, so a deauthorization
-        that skipped it would leave the athlete's data behind.
-        """
+        """The CDC table must be covered — it is where activity data now lives."""
         mock_client.execute_dml_query.side_effect = [0, 0, 0]
         service.run("12345", "corr-123", 1704067200)
 
@@ -49,12 +44,7 @@ class TestBQUserDeletionService:
         assert any("activities_live" in q for q in queries)
 
     def test_retains_no_copy_of_the_deleted_data(self, service, mock_client):
-        """Deletion must not archive the rows into another table.
-
-        An earlier version copied every row into `deleted_activities` as an
-        "audit trail", which retained exactly the data the deletion was required
-        to remove. The record is the log line instead.
-        """
+        """No archive table: a copy of the rows would defeat the deletion."""
         mock_client.execute_dml_query.side_effect = [1, 1, 1]
         service.run("12345", "corr-123", 1704067200)
 

--- a/packages/stravapipe/tests/unit/cloudrun/test_bq_inserter_app.py
+++ b/packages/stravapipe/tests/unit/cloudrun/test_bq_inserter_app.py
@@ -279,11 +279,10 @@ class TestDeleteEventHandling:
     """Tests for DELETE aspect_type handling."""
 
     def test_delete_event_success(self, client):
-        """DELETE event successfully archives and removes activity."""
+        """DELETE event removes the activity."""
         mock_service = client.app.state.delete_service
         mock_service.run.return_value = BQActivityDeletionResult(
             activity_id=12345678,
-            rows_archived=1,
             rows_deleted=1,
         )
 
@@ -312,7 +311,6 @@ class TestDeleteEventHandling:
         mock_service = client.app.state.delete_service
         mock_service.run.return_value = BQActivityDeletionResult(
             activity_id=12345678,
-            rows_archived=0,
             rows_deleted=0,
         )
 

--- a/packages/stravapipe/tests/unit/cloudrun/test_deletion_service_app.py
+++ b/packages/stravapipe/tests/unit/cloudrun/test_deletion_service_app.py
@@ -203,9 +203,9 @@ class TestDeauthEndpoint:
         """Full deletion across all stores returns 200."""
         # Mock BQ deletion
         mock_services["bq_deletion_service"].run.return_value = BQDeletionResult(
-            activities_archived=3,
             activities_deleted=3,
             staging_deleted=1,
+            live_deleted=2,
         )
 
         # Mock UoW context manager
@@ -288,12 +288,8 @@ class TestIdempotency:
         """
         # First call: data exists; second call: nothing left.
         mock_services["bq_deletion_service"].run.side_effect = [
-            BQDeletionResult(
-                activities_archived=3, activities_deleted=3, staging_deleted=1
-            ),
-            BQDeletionResult(
-                activities_archived=0, activities_deleted=0, staging_deleted=0
-            ),
+            BQDeletionResult(activities_deleted=3, staging_deleted=1, live_deleted=2),
+            BQDeletionResult(activities_deleted=0, staging_deleted=0, live_deleted=0),
         ]
 
         mock_uow = MagicMock()


### PR DESCRIPTION
Two problems in the deauthorization path.

**activities_live was not purged.** The service deleted from activities and activities_staging only, so an athlete who deauthorized left their rows in the CDC table — the one the pipeline now writes on every event, and the only BigQuery activity table left after the cutover. This is the Strava API Agreement §5.4 / GDPR erasure path, so the gap mattered more than its size.

**The "audit trail" retained the data it was deleting.** Both this service and the per-activity delete service first copied rows into `deleted_activities`. That table has 67 columns, of which 3 are deletion metadata; the other 64 are the activity payload — athlete, route polylines, start/end coordinates, photos, description. A deauthorization therefore moved the data rather than removing it, under a name that read as handled. Nothing has ever read the table.

Proving a deletion happened needs the athlete id, a timestamp, a row count and a correlation id. It does not need the data that was deleted. Those four are logged and retained in Cloud Logging, so the record survives without the personal data.

DML rather than CDC deletes for activities_live, deliberately. A per-activity delete already flows through CDC — the dispatcher publishes _CHANGE_TYPE=DELETE and the subscription applies it, with no DML and no service. But a deauthorization removes every activity an athlete has, which as CDC messages would be one publish per activity, thousands for an established account, and eventually consistent — against one DML statement that returns the count it deleted.

The deleted_activities table itself still exists and still holds data. Removing it needs its own change: deletion_protection is on in prod, so it takes a disable-then-destroy sequence.