### PR TITLE
feat(cutover): stop feeding bq-inserter from activity_events

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -6922,9 +6922,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/terraform/modules/desirelines/README.md
+++ b/terraform/modules/desirelines/README.md
@@ -43,8 +43,8 @@ module "desirelines" {
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
-| <a name="provider_google"></a> [google](#provider\_google) | 7.42.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 7.42.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 7.43.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 7.43.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Resources
@@ -150,7 +150,6 @@ module "desirelines" {
 | [google_pubsub_schema.activity_rows](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_schema) | resource |
 | [google_pubsub_subscription.activities_live_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription.activity_rows_dlq_monitoring](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
-| [google_pubsub_subscription.bq_inserter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription.bq_inserter_dlq](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription.dead_letter_monitoring](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription.deletion_service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |

--- a/terraform/modules/desirelines/main.tf
+++ b/terraform/modules/desirelines/main.tf
@@ -221,7 +221,6 @@ resource "google_pubsub_topic_iam_member" "dead_letter_publisher" {
 # and messages retry indefinitely instead of being forwarded after max_delivery_attempts
 resource "google_pubsub_subscription_iam_member" "dlq_subscriber" {
   for_each = toset([
-    google_pubsub_subscription.bq_inserter.name,
     google_pubsub_subscription.postgres_writer.name,
     google_pubsub_subscription.deletion_service.name,
   ])

--- a/terraform/modules/desirelines/outputs.tf
+++ b/terraform/modules/desirelines/outputs.tf
@@ -110,7 +110,6 @@ output "deployment_info" {
 output "pubsub_subscription_names" {
   description = "Names of Pub/Sub subscriptions for event processing"
   value = {
-    bq_inserter          = google_pubsub_subscription.bq_inserter.name
     postgres_writer      = google_pubsub_subscription.postgres_writer.name
     deletion_service     = google_pubsub_subscription.deletion_service.name
     bq_inserter_dlq      = google_pubsub_subscription.bq_inserter_dlq.name

--- a/terraform/modules/desirelines/pubsub_subscriptions.tf
+++ b/terraform/modules/desirelines/pubsub_subscriptions.tf
@@ -12,57 +12,15 @@
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
-# BQ Inserter Push Subscription
+# BQ Inserter Push Subscription — REMOVED (cutover step 1)
 # ------------------------------------------------------------------------------
-resource "google_pubsub_subscription" "bq_inserter" {
-  name  = "${var.project_name}-bq-inserter-${var.environment}"
-  topic = google_pubsub_topic.activity_events.name
-
-  # Push to Cloud Run service with CloudEvents format
-  push_config {
-    push_endpoint = "${google_cloud_run_v2_service.bq_inserter.uri}?__GCP_CloudEventsMode=CUSTOM_PUBSUB_${google_pubsub_topic.activity_events.id}"
-
-    oidc_token {
-      service_account_email = google_service_account.bq_inserter.email
-      audience              = google_cloud_run_v2_service.bq_inserter.uri
-    }
-
-    attributes = {
-      x-goog-version = "v1"
-    }
-  }
-
-  # Dead letter policy - failed messages go to DLQ after max attempts
-  dead_letter_policy {
-    dead_letter_topic     = google_pubsub_topic.dead_letter.id
-    max_delivery_attempts = 5
-  }
-
-  # Retry policy with exponential backoff
-  retry_policy {
-    minimum_backoff = "10s"
-    maximum_backoff = "600s"
-  }
-
-  # Cloud Run kills the request at 60s; this buffers the round-trip.
-  ack_deadline_seconds = 120
-
-  # Retain messages for 7 days (matches topic retention)
-  message_retention_duration = "604800s"
-
-  # Note: exactly-once delivery is not supported with push subscriptions
-  # Data consistency is achieved through idempotent handlers in the service
-
-  labels = merge(local.common_labels, {
-    service = "bq-inserter"
-    type    = "push-subscription"
-  })
-
-  depends_on = [
-    google_cloud_run_v2_service.bq_inserter,
-    google_project_service.required_apis
-  ]
-}
+# `activity_events` no longer feeds bq-inserter, so nothing writes to the
+# `activities` / `activities_staging` tables. Activity rows reach BigQuery
+# through the CDC subscription in bigquery_subscription.tf instead.
+#
+# The service, its DLQ wiring and the legacy tables are still here; they come
+# out in the following steps. Recreating this resource is the rollback.
+# ------------------------------------------------------------------------------
 
 # ------------------------------------------------------------------------------
 # PostgreSQL Writer Push Subscription


### PR DESCRIPTION
First step of the BigQuery cutover: remove the push subscription, so nothing writes to `activities` / `activities_staging` any more. Activity rows reach BigQuery through the CDC subscription instead, which has been running in parallel in prod and is now verified for upserts, deletes, metadata updates and publish-time schema validation.

Deliberately reversible and deliberately small. The bq-inserter service, its DLQ wiring, the alerts and the legacy tables all stay; recreating this one resource restores the old path. The service will idle to zero without traffic, so the saving starts here even though the deletions come later.

No reader is affected. Nothing queries the BigQuery `activities` table — apigateway reads PostgreSQL, and the only BigQuery consumers are writers.

History is not being carried across: `activities_live` starts from current events rather than being seeded, by choice. Seeding stays possible later, most likely by extending the backfill job to publish rows to the topic.

The deploy repo still names the bq-inserter *service* in redeploy.yml and the verify-services default list. Both are unaffected by this step and need updating when the service itself is removed.