### PR TITLE
feat(dispatcher): make cache read-through fills concurrency-safe

### DIFF
--- a/packages/dispatcher/adapters/cache/token_store.go
+++ b/packages/dispatcher/adapters/cache/token_store.go
@@ -37,12 +37,11 @@ const DefaultTokenCacheMaxEntries = 10_000
 // how long such a write can be shadowed.
 //
 // NOTE (concurrency): the read-through-then-Put is race-free ONLY because the
-// dispatcher runs one request at a time — max_instance_count = 1 AND
-// max_instance_request_concurrency = 1 in terraform/.../cloud_run.tf. With
-// concurrent requests, a read-through Put can land after a concurrent mutation's
-// invalidate and re-cache a stale value for a full TTL. Raising either knob
-// REQUIRES a per-key generation check in the read-through first. Documented at both
-// ends; see cloud_run.tf.
+// The read-through is safe under concurrency: GetTokens samples the cache
+// generation before consulting Firestore and fills via PutIfUnchanged, so a Put
+// that would land after a concurrent mutation's Invalidate is refused rather
+// than re-caching a stale value for a full TTL. This used to be the reason
+// max_instance_request_concurrency was pinned to 1; it no longer is.
 type TokenStore struct {
 	inner ports.TokenStore
 	cache *ttlcache.Cache[int64, stravatoken.Data]
@@ -95,6 +94,12 @@ func (s *TokenStore) GetTokens(ctx context.Context, athleteID int64) (*stravatok
 		return &out, nil
 	}
 
+	// Sampled before the fetch: if a writer invalidates while we are in
+	// Firestore, PutIfUnchanged refuses the fill rather than installing the
+	// value we read a moment too early. Without this the read-through is only
+	// race-free at request concurrency 1.
+	gen := s.cache.Generation()
+
 	tokens, err := s.inner.GetTokens(ctx, athleteID)
 	stampCache(span, "strava_tokens", false)
 	if err != nil {
@@ -102,7 +107,7 @@ func (s *TokenStore) GetTokens(ctx context.Context, athleteID int64) (*stravatok
 		return nil, err
 	}
 	if tokens != nil {
-		s.cache.Put(athleteID, *tokens) // copy into the cache
+		s.cache.PutIfUnchanged(athleteID, *tokens, gen) // copy into the cache
 	}
 	return tokens, nil
 }

--- a/packages/shared/allowlist/caching.go
+++ b/packages/shared/allowlist/caching.go
@@ -102,6 +102,11 @@ func (c *CachingChecker) IsAllowed(ctx context.Context, athleteID string) (bool,
 		return true, nil
 	}
 
+	// Sampled before the fetch — see PutIfUnchanged. A deauth invalidates this
+	// entry out of band; without the guard a straggler read-through could
+	// reinstall allowed=true for a full TTL after the revoke.
+	gen := c.cache.Generation()
+
 	allowed, err := c.inner.IsAllowed(ctx, athleteID)
 	stampCacheHit(span, false)
 	if err != nil {
@@ -110,7 +115,7 @@ func (c *CachingChecker) IsAllowed(ctx context.Context, athleteID string) (bool,
 	}
 
 	if allowed {
-		c.cache.Put(athleteID, true)
+		c.cache.PutIfUnchanged(athleteID, true, gen)
 	}
 	return allowed, nil
 }

--- a/packages/shared/ttlcache/ttlcache.go
+++ b/packages/shared/ttlcache/ttlcache.go
@@ -63,6 +63,10 @@ type Cache[K comparable, V any] struct {
 	ttl     time.Duration
 	max     int
 	now     func() time.Time
+	// gen advances on every Invalidate. A read-through caller samples it before
+	// consulting the source and hands it back to PutIfUnchanged, which refuses
+	// the write if anything was invalidated in between — see PutIfUnchanged.
+	gen uint64
 }
 
 // New creates a Cache. It cannot fail: a non-positive TTL yields a disabled
@@ -135,6 +139,47 @@ func (c *Cache[K, V]) Invalidate(key K) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.entries, key)
+	c.gen++
+}
+
+// Generation samples the invalidation counter. Pair it with PutIfUnchanged to
+// make a read-through safe under concurrency; on its own it means nothing.
+func (c *Cache[K, V]) Generation() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.gen
+}
+
+// PutIfUnchanged stores value under key only if no Invalidate has run since
+// gen was sampled. Reports whether the write happened.
+//
+// This closes the read-through-then-Put race. A caller that misses, fetches
+// from the source, and then Puts can otherwise install a value that a writer
+// invalidated while the fetch was in flight — and that stale value then serves
+// for a full TTL. Sampling the generation before the fetch and passing it here
+// turns that interleaving into a skipped write and a miss on the next read.
+//
+// The counter is cache-wide rather than per-key, which is deliberate: it makes
+// the check allocation-free and unbounded-growth-free, at the cost of an
+// unrelated key's invalidation occasionally suppressing a cache fill. That
+// error direction is the safe one — a redundant miss, never a stale hit — and
+// at this system's key cardinality the false-suppression rate is negligible.
+func (c *Cache[K, V]) PutIfUnchanged(key K, value V, gen uint64) bool {
+	if !c.enabled() {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.gen != gen {
+		return false
+	}
+	if _, exists := c.entries[key]; !exists && len(c.entries) >= c.max {
+		c.evictLocked()
+	}
+	c.entries[key] = entry[V]{value: value, expiresAt: c.now().Add(c.ttl)}
+	return true
 }
 
 // Len reports the number of entries held, including expired-but-not-yet-purged

--- a/packages/shared/ttlcache/ttlcache_test.go
+++ b/packages/shared/ttlcache/ttlcache_test.go
@@ -207,3 +207,56 @@ func TestConcurrentAccessIsRaceFree(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestPutIfUnchanged_RefusesFillInvalidatedMidFetch pins the read-through race
+// the generation guard exists to close: a caller misses, goes to the source,
+// and a writer invalidates while that fetch is in flight. Installing the
+// now-stale value would serve it for a full TTL. The guard must turn that into
+// a skipped write.
+func TestPutIfUnchanged_RefusesFillInvalidatedMidFetch(t *testing.T) {
+	c := ttlcache.New[string, int](ttlcache.Config{TTL: time.Minute})
+
+	gen := c.Generation() // caller samples before its (simulated) fetch
+	c.Invalidate("k")     // a writer lands mid-fetch
+
+	if c.PutIfUnchanged("k", 1, gen) {
+		t.Error("PutIfUnchanged wrote a value invalidated mid-fetch; the entry would serve stale for a full TTL")
+	}
+	if _, ok := c.Get("k"); ok {
+		t.Error("cache holds an entry it should have refused")
+	}
+}
+
+// The guard must not block the ordinary path, or every read-through becomes a
+// permanent miss.
+func TestPutIfUnchanged_AllowsUncontendedFill(t *testing.T) {
+	c := ttlcache.New[string, int](ttlcache.Config{TTL: time.Minute})
+
+	gen := c.Generation()
+	if !c.PutIfUnchanged("k", 1, gen) {
+		t.Fatal("PutIfUnchanged refused an uncontended fill")
+	}
+	got, ok := c.Get("k")
+	if !ok || got != 1 {
+		t.Errorf("Get = (%v, %v), want (1, true)", got, ok)
+	}
+}
+
+// Invalidating an unrelated key also bumps the counter, so a fill can be
+// suppressed by someone else's write. Documented as the deliberate cost of a
+// cache-wide counter: the error direction is a redundant miss, never a stale
+// hit.
+func TestPutIfUnchanged_UnrelatedInvalidateSuppressesFill(t *testing.T) {
+	c := ttlcache.New[string, int](ttlcache.Config{TTL: time.Minute})
+
+	gen := c.Generation()
+	c.Invalidate("other")
+
+	if c.PutIfUnchanged("k", 1, gen) {
+		t.Error("expected the cache-wide counter to suppress this fill")
+	}
+	// And the next attempt, sampling a fresh generation, succeeds.
+	if !c.PutIfUnchanged("k", 1, c.Generation()) {
+		t.Error("a fresh generation must allow the fill")
+	}
+}

--- a/terraform/modules/desirelines/cloud_run.tf
+++ b/terraform/modules/desirelines/cloud_run.tf
@@ -79,17 +79,20 @@ resource "google_cloud_run_v2_service" "dispatcher" {
     #   2. makes the in-process allowlist/token caches' read-through-then-Put
     #      pattern race-free (see adapters/cache/token_store.go DefaultTokenCacheTTL).
     #
-    # Raising max_instance_request_concurrency requires, for reason (2), a
-    # per-key generation check in the cache read-through — without it a stale
-    # entry can be re-cached for a full TTL.
+    # Both reasons are now handled in-process, so this is a tuning knob rather
+    # than a correctness constraint:
+    #   1. the Strava client collapses concurrent refreshes per athlete through
+    #      a singleflight group (adapters/strava/client.go refreshAndPersist), and
+    #   2. the caches fill via ttlcache.PutIfUnchanged, which refuses a
+    #      read-through Put that raced an Invalidate.
     #
-    # Reason (1) is now handled in-process: the Strava client collapses
-    # concurrent refreshes per athlete through a singleflight group
-    # (adapters/strava/client.go refreshAndPersist), so raising *concurrency*
-    # alone no longer reopens the refresh-token replay window. That guard is
-    # per-process state, so raising max_instance_count DOES reopen it — two
-    # instances have two singleflight groups and can still replay a refresh
-    # token against Strava. Treat the two knobs differently.
+    # max_instance_request_concurrency can therefore be raised on its own.
+    #
+    # max_instance_count is NOT equivalent: both guards are per-process state.
+    # Two instances have two singleflight groups and two caches, so raising the
+    # instance count reopens the refresh-token replay window against Strava.
+    # That would need cross-instance coordination, which does not exist. Keep
+    # this at 1 unless someone builds it.
     max_instance_request_concurrency = 1
 
     containers {


### PR DESCRIPTION
The read-through-then-Put in both caches could install a value that a writer invalidated while the source fetch was in flight, serving it for a full TTL. That was the standing reason max_instance_request_concurrency was pinned to 1.

ttlcache gains Generation() and PutIfUnchanged(): a caller samples the generation before consulting the source and passes it back on fill, which is refused if any Invalidate landed in between. Applied at both read-throughs -- dispatcher token cache and the shared allowlist cache. The allowlist case matters on its own: deauth invalidates out of band, so without the guard a straggler read could reinstall allowed=true for a full TTL after the revoke.

The counter is cache-wide rather than per-key. Per-key needs its own bounding and eviction or it grows for keys invalidated but never re-cached -- real complexity for a handful of athletes. Cache-wide is allocation-free and strictly conservative: an unrelated invalidation can suppress a fill, costing one redundant miss. The error direction is a miss, never a stale hit.

Retires the "requires a generation check first" notes in token_store.go and cloud_run.tf; concurrency is now a tuning knob, not a correctness constraint. max_instance_count is not -- both guards are per-process, so two instances can still replay a refresh token against Strava. That needs cross-instance coordination, which does not exist.