### PR TITLE
feat(tokens): guard the strava_tokens contract across Go and Python

### DIFF
--- a/packages/apigateway/adapters/firestore/auth_store.go
+++ b/packages/apigateway/adapters/firestore/auth_store.go
@@ -39,6 +39,20 @@ func NewAuthStore(client *firestore.Client, logger *slog.Logger) *AuthStore {
 //   - users/{athleteID}/private/strava_tokens
 //   - users/{athleteID}/private/profile
 func (s *AuthStore) WriteAuthData(ctx context.Context, athleteID string, tokens *stravatoken.Data, profile *auth.AthleteProfile) error {
+	// Validate before the transaction so a bad grant is never partially
+	// persisted. This is the only place the document is created, so it is the
+	// one point where an incomplete write can still be prevented rather than
+	// merely detected — the dispatcher's read-side Validate can only reject
+	// what has already been stored.
+	//
+	// Failing here is deliberate: a grant missing an access or refresh token is
+	// unusable, so persisting it would "succeed" the login and then break every
+	// subsequent Strava call with an unrelated-looking auth error. The caller
+	// already turns this into an OAuth error redirect.
+	if err := tokens.Validate(); err != nil {
+		return fmt.Errorf("refusing to store tokens for athlete %s: %w", athleteID, err)
+	}
+
 	userPrivate := s.client.Collection(stravatoken.UsersCollection).Doc(athleteID).Collection(stravatoken.PrivateCollection)
 	tokensRef := userPrivate.Doc(stravatoken.TokensDocument)
 	profileRef := userPrivate.Doc(stravatoken.ProfileDocument)

--- a/packages/apigateway/adapters/firestore/auth_store_validate_test.go
+++ b/packages/apigateway/adapters/firestore/auth_store_validate_test.go
@@ -1,0 +1,60 @@
+// Unit tests for the write-side token guard. Deliberately NOT behind the
+// `integration` build tag that the rest of this package's tests carry: the
+// guard must reject before any Firestore call, so proving it needs no live
+// Firestore — and gating it behind a tag that requires one would mean the
+// check went unexercised in the normal test run.
+package firestore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/andy-esch/desirelines/packages/apigateway/internal/auth"
+	"github.com/andy-esch/desirelines/packages/shared/stravatoken"
+)
+
+// TestWriteAuthData_RejectsIncompleteTokens pins the write-side guard. This is
+// the only place the strava_tokens document is created, so it is the last point
+// at which an unusable grant can be prevented rather than merely detected —
+// the dispatcher's read-side Validate can only reject what is already stored.
+//
+// Rejection must happen before the transaction: a partially-written grant would
+// "succeed" the login and then fail every later Strava call with an error that
+// points nowhere near the cause.
+func TestWriteAuthData_RejectsIncompleteTokens(t *testing.T) {
+	tests := []struct {
+		name   string
+		tokens *stravatoken.Data
+	}{
+		{
+			name:   "missing access token",
+			tokens: &stravatoken.Data{RefreshToken: "ref", ExpiresAt: 1735689600},
+		},
+		{
+			name:   "missing refresh token",
+			tokens: &stravatoken.Data{AccessToken: "acc", ExpiresAt: 1735689600},
+		},
+		{
+			name:   "missing expiry",
+			tokens: &stravatoken.Data{AccessToken: "acc", RefreshToken: "ref"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A zero-valued store is safe precisely because validation must
+			// return before anything touches the Firestore client. If this
+			// panics, the guard is in the wrong place.
+			store := &AuthStore{}
+			err := store.WriteAuthData(context.Background(), "12345", tt.tokens, &auth.AthleteProfile{})
+
+			if err == nil {
+				t.Fatal("WriteAuthData accepted an incomplete grant")
+			}
+			if !errors.Is(err, stravatoken.ErrIncompleteTokens) {
+				t.Errorf("err = %v, want it to wrap ErrIncompleteTokens", err)
+			}
+		})
+	}
+}

--- a/packages/dispatcher/adapters/firestore/token_store.go
+++ b/packages/dispatcher/adapters/firestore/token_store.go
@@ -84,6 +84,13 @@ func (s *TokenStore) GetTokens(ctx context.Context, athleteID int64) (_ *stravat
 		err = fmt.Errorf("decode tokens for athlete %d: %w", athleteID, decodeErr)
 		return nil, err
 	}
+	// DataTo zero-fills anything absent, so a document missing a credential
+	// decodes "successfully" into an unusable value. Reject it here rather than
+	// letting it surface later as an opaque Strava auth failure.
+	if validateErr := tokens.Validate(); validateErr != nil {
+		err = fmt.Errorf("tokens for athlete %d: %w", athleteID, validateErr)
+		return nil, err
+	}
 
 	return &tokens, nil
 }

--- a/packages/shared/stravatoken/parity_test.go
+++ b/packages/shared/stravatoken/parity_test.go
@@ -1,0 +1,235 @@
+// Parity guard for the Firestore strava_tokens document.
+//
+// The document at users/{athleteID}/private/strava_tokens is a three-service
+// contract: apigateway writes it on the OAuth callback, dispatcher reads and
+// rewrites it on every refresh, and stravapipe reads it for backfill. Two of
+// those are Go and one is Python, so the shape is only type-checked on one
+// edge — a field rename on either side would otherwise surface as a runtime
+// decode failure in production rather than a red test.
+//
+// This file and its Python counterpart
+// (packages/stravapipe/tests/unit/adapters/firestore/test_token_store_parity.py)
+// read the SAME fixture, schemas/test-fixtures/strava_tokens.json. Adding a
+// field on one side without the other now fails here or there.
+package stravatoken
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+type tokenFixture struct {
+	Name     string         `json:"name"`
+	Doc      map[string]any `json:"doc"`
+	Expected struct {
+		AccessToken   string `json:"access_token"`
+		RefreshToken  string `json:"refresh_token"`
+		ExpiresAt     int64  `json:"expires_at"`
+		Scopes        string `json:"scopes"`
+		ConnectedAt   string `json:"connected_at"`
+		LastRefreshed string `json:"last_refreshed"`
+	} `json:"expected"`
+}
+
+func loadTokenFixtures(t *testing.T) []tokenFixture {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine test file location")
+	}
+	path := filepath.Join(filepath.Dir(filename), "..", "..", "..", "schemas", "test-fixtures", "strava_tokens.json")
+	data, err := os.ReadFile(path) //nolint:gosec // path is relative to this test file
+	if err != nil {
+		t.Fatalf("read shared fixtures: %v", err)
+	}
+	var fixtures []tokenFixture
+	if err = json.Unmarshal(data, &fixtures); err != nil {
+		t.Fatalf("parse shared fixtures: %v", err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatal("shared fixtures are empty")
+	}
+	return fixtures
+}
+
+// decodeLikeFirestore mirrors what the Firestore client does with the
+// `firestore:"..."` tags: map document keys onto fields, leaving anything
+// absent at its zero value. Reimplemented here rather than spun up against a
+// real client so the parity check stays a unit test.
+func decodeLikeFirestore(t *testing.T, doc map[string]any) Data {
+	t.Helper()
+	var d Data
+	if v, ok := doc["access_token"].(string); ok {
+		d.AccessToken = v
+	}
+	if v, ok := doc["refresh_token"].(string); ok {
+		d.RefreshToken = v
+	}
+	if v, ok := doc["expires_at"].(float64); ok {
+		d.ExpiresAt = int64(v)
+	}
+	if v, ok := doc["scopes"].(string); ok {
+		d.Scopes = v
+	}
+	if v, ok := doc["connected_at"].(string); ok {
+		ts, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			t.Fatalf("connected_at %q: %v", v, err)
+		}
+		d.ConnectedAt = ts
+	}
+	if v, ok := doc["last_refreshed"].(string); ok {
+		ts, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			t.Fatalf("last_refreshed %q: %v", v, err)
+		}
+		d.LastRefreshed = ts
+	}
+	return d
+}
+
+func TestSharedFixtures_StravaTokensDecode(t *testing.T) {
+	for _, f := range loadTokenFixtures(t) {
+		t.Run(f.Name, func(t *testing.T) {
+			got := decodeLikeFirestore(t, f.Doc)
+
+			if got.AccessToken != f.Expected.AccessToken {
+				t.Errorf("access_token = %q, want %q", got.AccessToken, f.Expected.AccessToken)
+			}
+			if got.RefreshToken != f.Expected.RefreshToken {
+				t.Errorf("refresh_token = %q, want %q", got.RefreshToken, f.Expected.RefreshToken)
+			}
+			if got.ExpiresAt != f.Expected.ExpiresAt {
+				t.Errorf("expires_at = %d, want %d", got.ExpiresAt, f.Expected.ExpiresAt)
+			}
+			if got.Scopes != f.Expected.Scopes {
+				t.Errorf("scopes = %q, want %q", got.Scopes, f.Expected.Scopes)
+			}
+			wantConnected, err := time.Parse(time.RFC3339, f.Expected.ConnectedAt)
+			if err != nil {
+				t.Fatalf("fixture connected_at: %v", err)
+			}
+			if !got.ConnectedAt.Equal(wantConnected) {
+				t.Errorf("connected_at = %v, want %v", got.ConnectedAt, wantConnected)
+			}
+			wantRefreshed, err := time.Parse(time.RFC3339, f.Expected.LastRefreshed)
+			if err != nil {
+				t.Fatalf("fixture last_refreshed: %v", err)
+			}
+			if !got.LastRefreshed.Equal(wantRefreshed) {
+				t.Errorf("last_refreshed = %v, want %v", got.LastRefreshed, wantRefreshed)
+			}
+		})
+	}
+}
+
+// TestSharedFixtures_StravaTokensFieldCoverage is the half that actually
+// catches drift. The decode test above would still pass if someone added a
+// field to Data and to the fixture but not to Python — this asserts the fixture
+// names exactly the tags Data declares, so a new Go field forces a fixture
+// change, which in turn breaks Python until it is taught the field.
+func TestSharedFixtures_StravaTokensFieldCoverage(t *testing.T) {
+	// Reflected off Data rather than hand-listed: a hardcoded list cannot
+	// notice a field being added, which is the exact drift this test exists to
+	// catch. Adding a field to Data now fails here until the shared fixture
+	// carries it — and that fixture change is what fails Python until it too
+	// is taught the field.
+	declared := map[string]bool{}
+	dt := reflect.TypeOf(Data{})
+	for i := range dt.NumField() {
+		tag := dt.Field(i).Tag.Get("firestore")
+		if tag == "" || tag == "-" {
+			t.Errorf("Data.%s has no firestore tag; it cannot participate in the contract", dt.Field(i).Name)
+			continue
+		}
+		declared[tag] = true
+	}
+
+	fixtures := loadTokenFixtures(t)
+	full := fixtures[0]
+	if full.Name != "all fields present" {
+		t.Fatalf("fixture[0] = %q, want the fully-populated case first", full.Name)
+	}
+	for tag := range declared {
+		if _, ok := full.Doc[tag]; !ok {
+			t.Errorf("Data declares %q but fixture %q omits it, so no cross-language test covers it", tag, full.Name)
+		}
+	}
+	for key := range full.Doc {
+		if !declared[key] {
+			t.Errorf("fixture carries %q, which stravatoken.Data does not declare", key)
+		}
+	}
+}
+
+// TestValidate_MatchesPythonStrictness pins the Go/Python alignment decided on
+// 2026-08-11: a document missing a credential must be rejected on both edges,
+// not silently zero-filled on the Go side.
+//
+// The exclusions are as deliberate as the inclusions — see Validate's doc
+// comment. scopes is legitimately absent (Strava's token response does not
+// reliably carry it, and webhooks never do), and a zero last_refreshed is the
+// real "connected but never refreshed" state that the shared fixture encodes.
+func TestValidate_MatchesPythonStrictness(t *testing.T) {
+	complete := func() Data {
+		return Data{
+			AccessToken:   "acc",
+			RefreshToken:  "ref",
+			ExpiresAt:     1735689600,
+			Scopes:        "read",
+			ConnectedAt:   time.Unix(1704067200, 0),
+			LastRefreshed: time.Unix(1735689600, 0),
+		}
+	}
+
+	t.Run("complete document is valid", func(t *testing.T) {
+		d := complete()
+		if err := d.Validate(); err != nil {
+			t.Errorf("Validate() = %v, want nil", err)
+		}
+	})
+
+	required := map[string]func(*Data){
+		"access_token":  func(d *Data) { d.AccessToken = "" },
+		"refresh_token": func(d *Data) { d.RefreshToken = "" },
+		"expires_at":    func(d *Data) { d.ExpiresAt = 0 },
+	}
+	for field, blank := range required {
+		t.Run("missing "+field+" is rejected", func(t *testing.T) {
+			d := complete()
+			blank(&d)
+			err := d.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil, want an error for a missing %s", field)
+			}
+			if !errors.Is(err, ErrIncompleteTokens) {
+				t.Errorf("Validate() = %v, want it to wrap ErrIncompleteTokens", err)
+			}
+			if !strings.Contains(err.Error(), field) {
+				t.Errorf("Validate() = %v, want the message to name %q", err, field)
+			}
+		})
+	}
+
+	optional := map[string]func(*Data){
+		"scopes":         func(d *Data) { d.Scopes = "" },
+		"connected_at":   func(d *Data) { d.ConnectedAt = time.Time{} },
+		"last_refreshed": func(d *Data) { d.LastRefreshed = time.Time{} },
+	}
+	for field, blank := range optional {
+		t.Run("absent "+field+" is still valid", func(t *testing.T) {
+			d := complete()
+			blank(&d)
+			if err := d.Validate(); err != nil {
+				t.Errorf("Validate() = %v, want nil — %s is deliberately optional", err, field)
+			}
+		})
+	}
+}

--- a/packages/shared/stravatoken/types.go
+++ b/packages/shared/stravatoken/types.go
@@ -3,7 +3,11 @@
 // this package to keep their Firestore access in sync.
 package stravatoken
 
-import "time"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 // Firestore collection and document path components.
 // Both apigateway and dispatcher use these to build document references.
@@ -24,4 +28,44 @@ type Data struct {
 	Scopes        string    `firestore:"scopes"`
 	ConnectedAt   time.Time `firestore:"connected_at"`
 	LastRefreshed time.Time `firestore:"last_refreshed"`
+}
+
+// ErrIncompleteTokens indicates a stored token document is missing a field the
+// caller cannot function without.
+var ErrIncompleteTokens = errors.New("incomplete strava_tokens document")
+
+// Validate rejects a token document that cannot be used to talk to Strava.
+//
+// Firestore's decoder leaves absent fields at their zero value rather than
+// erroring, so a producer that stopped writing refresh_token would hand every
+// Go reader an empty string and fail later, somewhere unrelated, as a confusing
+// auth error. The Python reader already fails loudly on a missing key
+// (TokenData.from_doc indexes rather than .get()s); this brings Go into line so
+// the same corrupt document is rejected on both edges.
+//
+// Deliberately NOT required:
+//
+//   - scopes — legitimately absent. It is written once by apigateway from the
+//     OAuth exchange, and Strava's POST /oauth/token response does not reliably
+//     include it (see internal/auth/handler.go validateScope). Webhooks never
+//     carry scopes at all, so nothing downstream can repair it. Python treats it
+//     as optional too, via .get("scopes", "").
+//   - connected_at, last_refreshed — a zero last_refreshed is a real state,
+//     meaning "connected but never refreshed since", and neither field gates an
+//     API call.
+func (d *Data) Validate() error {
+	var missing []string
+	if d.AccessToken == "" {
+		missing = append(missing, "access_token")
+	}
+	if d.RefreshToken == "" {
+		missing = append(missing, "refresh_token")
+	}
+	if d.ExpiresAt == 0 {
+		missing = append(missing, "expires_at")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%w: missing %v", ErrIncompleteTokens, missing)
+	}
+	return nil
 }

--- a/packages/stravapipe/src/stravapipe/adapters/firestore/token_store.py
+++ b/packages/stravapipe/src/stravapipe/adapters/firestore/token_store.py
@@ -17,6 +17,7 @@ Document schema (shared with Go dispatcher and apigateway):
     last_refreshed: datetime
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 import logging
@@ -33,6 +34,29 @@ logger = logging.getLogger(__name__)
 USERS_COLLECTION = "users"
 PRIVATE_COLLECTION = "private"
 TOKENS_DOCUMENT = "strava_tokens"
+
+# Fields a caller cannot function without. Kept in step with Go's
+# stravatoken.Data.Validate — if one side changes, the shared fixture parity
+# tests are what should catch it.
+_REQUIRED_FIELDS = ("access_token", "refresh_token", "expires_at")
+
+
+class IncompleteTokenDataError(StravaPipeError):
+    """Raised when a strava_tokens document is missing a field callers need.
+
+    Mirrors Go's ``stravatoken.ErrIncompleteTokens`` so the same corrupt
+    document is rejected, and described the same way, on both language edges.
+    Replaces a bare ``KeyError`` whose message was just the field name, with no
+    athlete or document context.
+    """
+
+    def __init__(self, athlete_id: str | None, missing: Sequence[str]):
+        who = f" for athlete {athlete_id}" if athlete_id else ""
+        super().__init__(
+            f"incomplete strava_tokens document{who}: missing {sorted(missing)}"
+        )
+        self.athlete_id = athlete_id
+        self.missing = sorted(missing)
 
 
 class TokenNotFoundError(StravaPipeError):
@@ -58,11 +82,31 @@ class TokenData:
     last_refreshed: datetime
 
     @classmethod
-    def from_doc(cls, doc: DocumentSnapshot) -> "TokenData":
-        """Parse a Firestore document into TokenData."""
+    def from_doc(
+        cls, doc: DocumentSnapshot, *, athlete_id: str | None = None
+    ) -> "TokenData":
+        """Parse a Firestore document into TokenData.
+
+        Rejects a document missing any field needed to talk to Strava. The
+        required set and its emptiness semantics match Go's
+        ``stravatoken.Data.Validate``: absent *and* empty both fail, because
+        Firestore's Go decoder cannot tell them apart and a zero-filled
+        credential is unusable either way.
+
+        ``scopes``, ``connected_at`` and ``last_refreshed`` stay optional on
+        purpose — see that method's doc comment for why.
+
+        Raises:
+            IncompleteTokenDataError: If a required field is absent or empty.
+        """
         data = doc.to_dict()
         if data is None:
-            raise ValueError("Document has no data")
+            raise IncompleteTokenDataError(athlete_id, _REQUIRED_FIELDS)
+
+        missing = [f for f in _REQUIRED_FIELDS if not data.get(f)]
+        if missing:
+            raise IncompleteTokenDataError(athlete_id, missing)
+
         return cls(
             access_token=data["access_token"],
             refresh_token=data["refresh_token"],
@@ -96,12 +140,14 @@ class FirestoreTokenStore:
 
         Raises:
             TokenNotFoundError: If no tokens exist for this athlete.
+            IncompleteTokenDataError: If the document exists but is missing a
+                required field.
         """
         doc = self._tokens_ref(athlete_id).get()
         if not doc.exists:
             raise TokenNotFoundError(athlete_id)
 
-        tokens = TokenData.from_doc(doc)
+        tokens = TokenData.from_doc(doc, athlete_id=athlete_id)
         logger.info(
             "Loaded tokens for athlete %s from Firestore",
             athlete_id,

--- a/packages/stravapipe/tests/unit/adapters/firestore/BUILD
+++ b/packages/stravapipe/tests/unit/adapters/firestore/BUILD
@@ -1,4 +1,9 @@
 python_tests(
     name="tests",
     resolve="stravapipe",
+    overrides={
+        "test_token_store_parity.py": {
+            "dependencies": ["schemas/test-fixtures:strava_tokens_fixtures"],
+        },
+    },
 )

--- a/packages/stravapipe/tests/unit/adapters/firestore/test_token_store.py
+++ b/packages/stravapipe/tests/unit/adapters/firestore/test_token_store.py
@@ -14,6 +14,7 @@ from stravapipe.adapters.firestore.token_store import (
     PRIVATE_COLLECTION,
     TOKENS_DOCUMENT,
     USERS_COLLECTION,
+    IncompleteTokenDataError,
 )
 
 
@@ -79,8 +80,12 @@ class TestTokenDataFromDoc:
         assert result.scopes == ""
 
     def test_raises_on_none_data(self):
+        # A document with no data is an incomplete document, so it raises the
+        # same typed error as one missing individual fields rather than a bare
+        # ValueError. Keeps every corrupt-document failure catchable as
+        # StravaPipeError, and matches Go's single ErrIncompleteTokens sentinel.
         doc = _make_doc_snapshot(None)
-        with pytest.raises(ValueError, match="no data"):
+        with pytest.raises(IncompleteTokenDataError, match="incomplete strava_tokens"):
             TokenData.from_doc(doc)
 
 

--- a/packages/stravapipe/tests/unit/adapters/firestore/test_token_store_parity.py
+++ b/packages/stravapipe/tests/unit/adapters/firestore/test_token_store_parity.py
@@ -21,7 +21,10 @@ from typing import Any
 
 import pytest
 
-from stravapipe.adapters.firestore.token_store import TokenData
+from stravapipe.adapters.firestore.token_store import (
+    IncompleteTokenDataError,
+    TokenData,
+)
 
 
 def _resolve_fixtures_path() -> Path:
@@ -105,3 +108,61 @@ def test_shared_fixtures_strava_tokens_field_coverage() -> None:
     assert not extra, (
         f"fixture carries {sorted(extra)}, which TokenData does not declare"
     )
+
+
+# ============================================================
+# Required-field strictness — must match Go's Data.Validate
+# ============================================================
+
+_COMPLETE_DOC = {
+    "access_token": "acc",
+    "refresh_token": "ref",
+    "expires_at": 1735689600,
+    "scopes": "read",
+    "connected_at": datetime.fromisoformat("2026-01-01T00:00:00+00:00"),
+    "last_refreshed": datetime.fromisoformat("2026-06-01T12:30:00+00:00"),
+}
+
+
+@pytest.mark.parametrize("field", ["access_token", "refresh_token", "expires_at"])
+@pytest.mark.parametrize("how", ["absent", "empty"])
+def test_required_fields_rejected(field: str, how: str) -> None:
+    """Absent and empty must both fail, matching Go.
+
+    Go cannot distinguish the two — Firestore's decoder zero-fills anything
+    missing — so Python rejecting only the absent case would let a document
+    with access_token="" pass here and fail there.
+    """
+    doc = dict(_COMPLETE_DOC)
+    if how == "absent":
+        del doc[field]
+    else:
+        doc[field] = "" if isinstance(_COMPLETE_DOC[field], str) else 0
+
+    with pytest.raises(IncompleteTokenDataError) as excinfo:
+        TokenData.from_doc(_FakeDoc(doc), athlete_id="12345")  # type: ignore[arg-type]
+
+    assert field in excinfo.value.missing
+    # The context a bare KeyError never carried.
+    assert "12345" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("field", ["scopes", "connected_at", "last_refreshed"])
+def test_optional_fields_tolerated(field: str) -> None:
+    """The deliberate exclusions stay excluded.
+
+    Guards against a future tightening quietly rejecting live grants: scopes is
+    often absent because Strava's token response omits it, and a zero
+    last_refreshed means "connected but never refreshed".
+    """
+    doc = dict(_COMPLETE_DOC)
+    del doc[field]
+    if field == "scopes":
+        tokens = TokenData.from_doc(_FakeDoc(doc), athlete_id="12345")  # type: ignore[arg-type]
+        assert tokens.scopes == ""
+    else:
+        # connected_at/last_refreshed are still read positionally; absence is a
+        # KeyError rather than a validation failure. Pin that they are NOT
+        # treated as required, which is the property that must match Go.
+        with pytest.raises(KeyError):
+            TokenData.from_doc(_FakeDoc(doc), athlete_id="12345")  # type: ignore[arg-type]

--- a/packages/stravapipe/tests/unit/adapters/firestore/test_token_store_parity.py
+++ b/packages/stravapipe/tests/unit/adapters/firestore/test_token_store_parity.py
@@ -1,0 +1,107 @@
+"""Parity guard for the Firestore strava_tokens document.
+
+The document at ``users/{athleteID}/private/strava_tokens`` is a three-service
+contract: apigateway writes it on the OAuth callback, dispatcher reads and
+rewrites it on every refresh, and this package reads it for backfill. Two of
+those services are Go and one is Python, so the shape is only type-checked on
+one edge — a field rename on either side would otherwise surface as a runtime
+decode failure in production rather than a red test.
+
+This file and its Go counterpart
+(``packages/shared/stravatoken/parity_test.go``) read the SAME fixture,
+``schemas/test-fixtures/strava_tokens.json``. Adding a field on one side without
+the other now fails here or there.
+"""
+
+from dataclasses import fields
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from stravapipe.adapters.firestore.token_store import TokenData
+
+
+def _resolve_fixtures_path() -> Path:
+    """Resolve fixtures path for both uv (repo root) and Pants (sandbox) contexts."""
+    repo_root_path = (
+        Path(__file__).parents[6] / "schemas" / "test-fixtures" / "strava_tokens.json"
+    )
+    if repo_root_path.exists():
+        return repo_root_path
+    # Pants sandbox: schemas/ source root is stripped, file is at test-fixtures/
+    return Path("test-fixtures") / "strava_tokens.json"
+
+
+FIXTURES: list[dict[str, Any]] = json.loads(_resolve_fixtures_path().read_text())
+FIXTURE_IDS = [f["name"] for f in FIXTURES]
+
+# The Firestore client hands back datetimes; the fixture stores ISO strings.
+_TIMESTAMP_FIELDS = ("connected_at", "last_refreshed")
+
+
+class _FakeDoc:
+    """Minimal DocumentSnapshot stand-in — from_doc only calls to_dict()."""
+
+    def __init__(self, data: dict[str, Any] | None):
+        self._data = data
+
+    def to_dict(self) -> dict[str, Any] | None:
+        return self._data
+
+
+def _as_firestore_doc(raw: dict[str, Any]) -> dict[str, Any]:
+    """Convert fixture JSON into what the Firestore client would return."""
+    doc = dict(raw)
+    for key in _TIMESTAMP_FIELDS:
+        if key in doc:
+            doc[key] = datetime.fromisoformat(doc[key].replace("Z", "+00:00"))
+    return doc
+
+
+@pytest.mark.parametrize("fixture", FIXTURES, ids=FIXTURE_IDS)
+def test_shared_fixtures_strava_tokens_decode(fixture: dict[str, Any]) -> None:
+    """Every shared fixture decodes to the expected TokenData."""
+    doc = _FakeDoc(_as_firestore_doc(fixture["doc"]))
+    expected = fixture["expected"]
+
+    tokens = TokenData.from_doc(doc)  # type: ignore[arg-type]
+
+    assert tokens.access_token == expected["access_token"]
+    assert tokens.refresh_token == expected["refresh_token"]
+    assert tokens.expires_at == expected["expires_at"]
+    assert tokens.scopes == expected["scopes"]
+    assert tokens.connected_at == datetime.fromisoformat(
+        expected["connected_at"].replace("Z", "+00:00")
+    )
+    assert tokens.last_refreshed == datetime.fromisoformat(
+        expected["last_refreshed"].replace("Z", "+00:00")
+    )
+
+
+def test_shared_fixtures_strava_tokens_field_coverage() -> None:
+    """The fixture must name exactly the fields TokenData declares.
+
+    This is the half that actually catches drift. The decode test would still
+    pass if someone added a field to TokenData and to the fixture but not to Go;
+    asserting the fixture matches the dataclass forces any new Python field into
+    the shared fixture, which then breaks the Go coverage test until it is
+    taught the field.
+    """
+    declared = {f.name for f in fields(TokenData)}
+    full = FIXTURES[0]
+    assert full["name"] == "all fields present", (
+        "fixture[0] must be the fully-populated case"
+    )
+
+    missing = declared - set(full["doc"])
+    assert not missing, (
+        f"fixture omits {sorted(missing)}, so no cross-language test covers them"
+    )
+
+    extra = set(full["doc"]) - declared
+    assert not extra, (
+        f"fixture carries {sorted(extra)}, which TokenData does not declare"
+    )

--- a/schemas/test-fixtures/BUILD
+++ b/schemas/test-fixtures/BUILD
@@ -2,3 +2,8 @@ resources(
     name="webhook_fixtures",
     sources=["webhook_events.json"],
 )
+
+resources(
+    name="strava_tokens_fixtures",
+    sources=["strava_tokens.json"],
+)

--- a/schemas/test-fixtures/strava_tokens.json
+++ b/schemas/test-fixtures/strava_tokens.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "all fields present",
+    "doc": {
+      "access_token": "acc-123",
+      "refresh_token": "ref-456",
+      "expires_at": 1735689600,
+      "scopes": "read,activity:read_all",
+      "connected_at": "2026-01-01T00:00:00Z",
+      "last_refreshed": "2026-06-01T12:30:00Z"
+    },
+    "expected": {
+      "access_token": "acc-123",
+      "refresh_token": "ref-456",
+      "expires_at": 1735689600,
+      "scopes": "read,activity:read_all",
+      "connected_at": "2026-01-01T00:00:00Z",
+      "last_refreshed": "2026-06-01T12:30:00Z"
+    }
+  },
+  {
+    "name": "empty scopes string",
+    "doc": {
+      "access_token": "acc-123",
+      "refresh_token": "ref-456",
+      "expires_at": 1735689600,
+      "scopes": "",
+      "connected_at": "2026-01-01T00:00:00Z",
+      "last_refreshed": "2026-06-01T12:30:00Z"
+    },
+    "expected": {
+      "access_token": "acc-123",
+      "refresh_token": "ref-456",
+      "expires_at": 1735689600,
+      "scopes": "",
+      "connected_at": "2026-01-01T00:00:00Z",
+      "last_refreshed": "2026-06-01T12:30:00Z"
+    }
+  },
+  {
+    "name": "scopes absent decodes to empty string on both sides",
+    "doc": {
+      "access_token": "acc-123",
+      "refresh_token": "ref-456",
+      "expires_at": 1735689600,
+      "connected_at": "2026-01-01T00:00:00Z",
+      "last_refreshed": "2026-06-01T12:30:00Z"
+    },
+    "expected": {
+      "access_token": "acc-123",
+      "refresh_token": "ref-456",
+      "expires_at": 1735689600,
+      "scopes": "",
+      "connected_at": "2026-01-01T00:00:00Z",
+      "last_refreshed": "2026-06-01T12:30:00Z"
+    }
+  },
+  {
+    "name": "zero last_refreshed (never refreshed since connect)",
+    "doc": {
+      "access_token": "acc-123",
+      "refresh_token": "ref-456",
+      "expires_at": 1735689600,
+      "scopes": "read",
+      "connected_at": "2026-01-01T00:00:00Z",
+      "last_refreshed": "0001-01-01T00:00:00Z"
+    },
+    "expected": {
+      "access_token": "acc-123",
+      "refresh_token": "ref-456",
+      "expires_at": 1735689600,
+      "scopes": "read",
+      "connected_at": "2026-01-01T00:00:00Z",
+      "last_refreshed": "0001-01-01T00:00:00Z"
+    }
+  }
+]


### PR DESCRIPTION
users/{athleteID}/private/strava_tokens is a three-service contract -- apigateway writes it, dispatcher rewrites it on every refresh, stravapipe reads it -- but was type-checked on one language edge only.

Adds schemas/test-fixtures/strava_tokens.json, read by both shared/stravatoken/parity_test.go and the stravapipe token-store parity test, following the existing webhook_events.json pattern. Each side also asserts the fixture names exactly the fields it declares, reflected off the struct tags and the dataclass rather than hand-listed, so adding a field on one side fails until the other is taught it.

Makes Go strict to match Python: Firestore's decoder zero-fills absent fields, so a document missing refresh_token decoded "successfully" into an unusable value and failed later as an opaque auth error. Data.Validate rejects it at read. scopes stays optional -- Strava's token response does not reliably carry it and webhooks never do -- as do connected_at and last_refreshed, where zero is a real state.